### PR TITLE
Fix package build on Conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ script:
 # Unit tests and dynamic linting
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - if [[ $TRAVIS_TAG ]]; then
-    conda build -q tools/conda.recipe;
+    conda build tools/conda.recipe;
   else
     python setup.py build_ext -i --define CYTHON_TRACE_NOGIL &&
     nosetests ${PROJECT_NAME}

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -17,14 +17,18 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python ={{ MYCONDAPY }}
-    - numpy
+    - numpy >=1.0
     - cython >=0.24.1
     - setuptools
     - nose
     - matplotlib
+    - scipy
   run:
     - python
+    - numpy >=1.0
     - scipy
+    - matplotlib
+    - nose
 test:
   requires:
     - nose


### PR DESCRIPTION
- All run requirements have to be included in host requirements.
- Run requirements should be consistent with setup.py

This should make it possible again to release versions of grid.