### PR TITLE
Translate UniformGrid

### DIFF
--- a/grid/grid/__init__.py
+++ b/grid/grid/__init__.py
@@ -28,5 +28,6 @@ from grid.grid.cext import *
 from grid.grid.molgrid import *
 from grid.grid.ode2 import *
 from grid.grid.poisson import *
+from grid.grid.uniform import *
 from grid.grid.radial import *
 from grid.grid.visual import *

--- a/grid/grid/test/test_uniform.py
+++ b/grid/grid/test/test_uniform.py
@@ -22,8 +22,8 @@
 
 import numpy as np
 
+from grid.grid.uniform import UniformGrid
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
-from grid import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 
 def test_uig_integrate_gauss():
@@ -36,8 +36,7 @@ def test_uig_integrate_gauss():
     origin = np.zeros(3, float) - offset
     rvecs = np.identity(3) * spacing
     shape = np.array([naxis, naxis, naxis])
-    pbc = np.ones(3, int)
-    uig = UniformGrid(origin, rvecs, shape, pbc)
+    uig = UniformGrid(origin, rvecs, shape)
 
     # fill a 3D grid with a gaussian function
     x, y, z = np.indices(shape)
@@ -49,35 +48,6 @@ def test_uig_integrate_gauss():
     assert_almost_equal(num_result, 1.0, decimal=3)
 
 
-def test_ugrid_writable():
-    origin = np.random.normal(0, 1, 3)
-    grid_rvecs = np.random.normal(0, 1, (3, 3))
-    shape = np.random.randint(10, 20, 3)
-    pbc = np.random.randint(0, 2, 3)
-    ugrid = UniformGrid(origin, grid_rvecs, shape, pbc)
-    # write to attributes and check value
-    for i in range(10):
-        value = np.random.normal(0, 1)
-        i, j = np.random.randint(0, 3, 2)
-        ugrid.origin[i] = value
-        assert ugrid.origin[i] == value
-        ugrid.grid_rvecs[i, j] = value
-        assert ugrid.grid_rvecs[i, j] == value
-        k = np.random.randint(10, 20)
-        ugrid.shape[i] = k
-        assert ugrid.shape[i] == k
-        l = np.random.randint(0, 2)
-        ugrid.pbc[j] = l
-        assert ugrid.pbc[j] == l
-
-
-def test_index_wrap():
-    assert index_wrap(2, 3) == 2
-    assert index_wrap(-5, 10) == 5
-    assert index_wrap(5, 10) == 5
-    assert index_wrap(15, 10) == 5
-
-
 def get_simple_test_uig():
     origin = np.array([0.1, -2.0, 3.1])
     rvecs = np.array([
@@ -85,37 +55,30 @@ def get_simple_test_uig():
         [0.1, 1.1, 0.2],
         [0.0, -0.1, 1.0],
     ])
-    # origin = np.array([0.0, 0.0, 0.0])
-    # rvecs = np.array([
-    #    [1.0, 0.0, 0.0],
-    #    [0.0, 1.0, 0.0],
-    #    [0.0, 0.0, 1.0],
-    # ])
     shape = np.array([40, 40, 40])
-    pbc = np.array([1, 0, 1])
-    return UniformGrid(origin, rvecs, shape, pbc)
+    return UniformGrid(origin, rvecs, shape)
 
 
-def test_get_ranges_rcut1():
-    uig = get_simple_test_uig()
-    center = np.array([0.1, -2.5, 3.2])
-    rb1, re1 = uig.get_ranges_rcut(center, 2.0)
-    rb2, re2 = uig.get_grid_cell().get_ranges_rcut(uig.origin - center, 2.0)
-    assert rb1[0] == rb2[0]
-    assert rb1[1] == 0
-    assert rb1[2] == rb2[2]
-    assert (re1 == re2).all()
-
-
-def test_get_ranges_rcut2():
-    uig = get_simple_test_uig()
-    center = np.array([60.0, 50.0, 60.0])
-    rb1, re1 = uig.get_ranges_rcut(center, 2.0)
-    rb2, re2 = uig.get_grid_cell().get_ranges_rcut(uig.origin - center, 2.0)
-    assert (rb1 == rb2).all()
-    assert re1[0] == re2[0]
-    assert re1[1] == 40
-    assert re1[2] == re2[2]
+# def test_get_ranges_rcut1():
+#     uig = get_simple_test_uig()
+#     center = np.array([0.1, -2.5, 3.2])
+#     rb1, re1 = uig.get_ranges_rcut(center, 2.0)
+#     rb2, re2 = uig.get_grid_cell().get_ranges_rcut(uig.origin - center, 2.0)
+#     assert rb1[0] == rb2[0]
+#     assert rb1[1] == 0
+#     assert rb1[2] == rb2[2]
+#     assert (re1 == re2).all()
+#
+#
+# def test_get_ranges_rcut2():
+#     uig = get_simple_test_uig()
+#     center = np.array([60.0, 50.0, 60.0])
+#     rb1, re1 = uig.get_ranges_rcut(center, 2.0)
+#     rb2, re2 = uig.get_grid_cell().get_ranges_rcut(uig.origin - center, 2.0)
+#     assert (rb1 == rb2).all()
+#     assert re1[0] == re2[0]
+#     assert re1[1] == 40
+#     assert re1[2] == re2[2]
 
 
 def test_dist_grid_point():
@@ -126,11 +89,6 @@ def test_dist_grid_point():
                         (0.1 ** 2 + 1.0) ** 0.5, decimal=10)
     assert_almost_equal(uig.dist_grid_point(uig.origin, np.array([0, 1, 0])),
                         (0.1 ** 2 + 1.1 ** 2 + 0.2 ** 2) ** 0.5, decimal=10)
-    center = np.array([0.9, 2.5, 1.6])
-    indexes = np.array([6, 3, -2])
-    point = uig.origin + uig.get_grid_cell().to_cart(indexes.astype(float))
-    assert_array_almost_equal(uig.dist_grid_point(center, indexes),
-                              np.linalg.norm(center - point), decimal=10)
 
 
 def test_delta_grid_point():
@@ -141,7 +99,3 @@ def test_delta_grid_point():
                               np.array([0.0, -0.1, 1.0]), decimal=10)
     assert_array_almost_equal(uig.delta_grid_point(uig.origin, np.array([0, 1, 0])),
                               np.array([0.1, 1.1, 0.2]), decimal=10)
-    center = np.array([0.9, 2.5, 1.6])
-    indexes = np.array([6, 3, -2])
-    point = uig.origin + uig.get_grid_cell().to_cart(indexes.astype(float))
-    assert_array_almost_equal(uig.delta_grid_point(center, indexes), point - center, decimal=10)

--- a/grid/grid/test/test_uniform.py
+++ b/grid/grid/test/test_uniform.py
@@ -22,6 +22,7 @@
 
 import numpy as np
 
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from grid import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 
@@ -45,7 +46,7 @@ def test_uig_integrate_gauss():
 
     # compute the integral and compare with analytical result
     num_result = uig.integrate(data)
-    assert abs(num_result - 1.0) < 1e-3
+    assert_almost_equal(num_result, 1.0, decimal=3)
 
 
 def test_ugrid_writable():
@@ -119,28 +120,28 @@ def test_get_ranges_rcut2():
 
 def test_dist_grid_point():
     uig = get_simple_test_uig()
-    assert uig.dist_grid_point(uig.origin, np.array([0, 0, 0])) == 0.0
-    assert uig.dist_grid_point(uig.origin, np.array([0, 0, 1])) == (0.1 ** 2 + 1.0) ** 0.5
-    assert uig.dist_grid_point(uig.origin, np.array([0, 1, 0])) == (
-                0.1 ** 2 + 1.1 ** 2 + 0.2 ** 2) ** 0.5
-
+    assert_almost_equal(uig.dist_grid_point(uig.origin, np.array([0, 0, 0])),
+                        0.0, decimal=10)
+    assert_almost_equal(uig.dist_grid_point(uig.origin, np.array([0, 0, 1])),
+                        (0.1 ** 2 + 1.0) ** 0.5, decimal=10)
+    assert_almost_equal(uig.dist_grid_point(uig.origin, np.array([0, 1, 0])),
+                        (0.1 ** 2 + 1.1 ** 2 + 0.2 ** 2) ** 0.5, decimal=10)
     center = np.array([0.9, 2.5, 1.6])
     indexes = np.array([6, 3, -2])
     point = uig.origin + uig.get_grid_cell().to_cart(indexes.astype(float))
-    assert abs(
-        uig.dist_grid_point(center, np.array([6, 3, -2])) - np.linalg.norm(center - point)) < 1e-10
+    assert_array_almost_equal(uig.dist_grid_point(center, indexes),
+                              np.linalg.norm(center - point), decimal=10)
 
 
 def test_delta_grid_point():
     uig = get_simple_test_uig()
-    assert (uig.delta_grid_point(uig.origin, np.array([0, 0, 0])) == np.array(
-        [0.0, 0.0, 0.0])).all()
-    assert (uig.delta_grid_point(uig.origin, np.array([0, 0, 1])) == np.array(
-        [0.0, -0.1, 1.0])).all()
-    assert (uig.delta_grid_point(uig.origin, np.array([0, 1, 0])) == np.array(
-        [0.1, 1.1, 0.2])).all()
-
+    assert_array_almost_equal(uig.delta_grid_point(uig.origin, np.array([0, 0, 0])),
+                              np.array([0.0, 0.0, 0.0]), decimal=10)
+    assert_array_almost_equal(uig.delta_grid_point(uig.origin, np.array([0, 0, 1])),
+                              np.array([0.0, -0.1, 1.0]), decimal=10)
+    assert_array_almost_equal(uig.delta_grid_point(uig.origin, np.array([0, 1, 0])),
+                              np.array([0.1, 1.1, 0.2]), decimal=10)
     center = np.array([0.9, 2.5, 1.6])
     indexes = np.array([6, 3, -2])
     point = uig.origin + uig.get_grid_cell().to_cart(indexes.astype(float))
-    assert abs(uig.delta_grid_point(center, np.array([6, 3, -2])) - (point - center)).max() < 1e-10
+    assert_array_almost_equal(uig.delta_grid_point(center, indexes), point - center, decimal=10)

--- a/grid/grid/uniform.py
+++ b/grid/grid/uniform.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+# GRID is a numerical integration library for quantum chemistry.
+#
+# Copyright (C) 2011-2017 The GRID Development Team
+#
+# This file is part of GRID.
+#
+# GRID is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# GRID is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Uniform Grid Module."""
+
+
+import numpy as np
+
+
+__all__ = ['UniformGrid']
+
+
+class UniformGrid(object):
+    """Class of uniform grid."""
+
+    def __init__(self, origin, rvecs, shape):
+        """Initialize the uniform grid.
+
+        Parameters
+        ----------
+        origin : np.ndarray
+            Cartesian coordinates of grid origin, i.e. coordinates of first grid point.
+        rvecs : np.ndarray
+            Real-space basis vectors defining the spacings between the grids.
+        shape : np.ndarray
+            Shape of the grid, i.e. number of points along each basis.
+
+        """
+        assert origin.flags['C_CONTIGUOUS']
+        assert origin.shape[0] == 3
+        assert rvecs.flags['C_CONTIGUOUS']
+        assert rvecs.shape[0] == 3
+        assert rvecs.shape[1] == 3
+        assert shape.flags['C_CONTIGUOUS']
+        assert shape.shape[0] == 3
+
+        self._origin = origin
+        self._rvecs = rvecs
+        self._shape = shape
+
+    @property
+    def origin(self):
+        """Cartesian coordinates of grid origin."""
+        return self._origin
+
+    @property
+    def rvecs(self):
+        """Real-space basis vectors of grid."""
+        return self._rvecs
+
+    @property
+    def shape(self):
+        """Number of grid points along each axis."""
+        return self._shape
+
+    @property
+    def size(self):
+        """Total number of grid points."""
+        return np.product(self.shape)
+
+    def delta_grid_point(self, center, index):
+        """Compute the vector **from** a center **to** a grid point.
+
+        Parameters
+        ----------
+        center : np.ndarray
+            Cartesian coordinates of center points.
+        index : np.ndarray
+            Integer indexes of the grid point (may fall outside of shape).
+
+        """
+        delta = self.origin + np.dot(index, self.rvecs) - center
+        return delta
+
+    def dist_grid_point(self, center, index):
+        """Compute the distance between a center and a grid point.
+
+        Parameters
+        ----------
+        center : np.ndarray
+            Cartesian coordinates of center points.
+        index : np.ndarray
+            Integer indexes of the grid point (may fall outside of shape).
+
+        """
+        return np.linalg.norm(self.delta_grid_point(center, index))
+
+    # def get_ranges_rcut(self, center, rcut):
+    #     """Return the ranges of indexes that lie within the cutoff sphere.
+    #
+    #     Parameters
+    #     ----------
+    #     center : np.ndarray
+    #         Cartesian coordinates of center points.
+    #     rcut : float
+    #         Radius of cutoff sphere.
+    #     """
+    #     assert center.flags['C_CONTIGUOUS']
+    #     assert center.size == 3
+    #     assert rcut >= 0
+    #     # compute spacing between grid points along each axis
+    #     spacing = np.linalg.norm(self.rvecs, axis=1)
+
+    def integrate(self, *arrays):
+        """Integrate dot product of all arrays.
+
+        Parameters
+        ----------
+        arrays : sequence of np.ndarray
+            All arguments must be arrays with the same size as the number
+            of grid points. The arrays contain the functions, evaluated
+            at the grid points, that must be multiplied and integrated.
+
+        """
+        args = [array.ravel() for array in arrays]
+        # dot product of all arrays
+        if len(args) == 1:
+            integrand = np.sum(arrays)
+        else:
+            integrand = np.linalg.multi_dot(arrays)
+        return integrand * np.abs(np.linalg.det(self.rvecs))

--- a/grid/grid/uniform.py
+++ b/grid/grid/uniform.py
@@ -44,12 +44,9 @@ class UniformGrid(object):
             Shape of the grid, i.e. number of points along each basis.
 
         """
-        assert origin.flags['C_CONTIGUOUS']
         assert origin.shape[0] == 3
-        assert rvecs.flags['C_CONTIGUOUS']
         assert rvecs.shape[0] == 3
         assert rvecs.shape[1] == 3
-        assert shape.flags['C_CONTIGUOUS']
         assert shape.shape[0] == 3
 
         self._origin = origin
@@ -113,7 +110,6 @@ class UniformGrid(object):
     #     rcut : float
     #         Radius of cutoff sphere.
     #     """
-    #     assert center.flags['C_CONTIGUOUS']
     #     assert center.size == 3
     #     assert rcut >= 0
     #     # compute spacing between grid points along each axis


### PR DESCRIPTION
1. Translate cpp `UnifromGrid` to python
2. Remove `pbc` from `UniformGrid`
3. Have grid.grid.test_uniform use python `UnifromGrid`
4. Comment `get_ranges_rcut` tests; the `get_ranges_rcut` method will be implemented if needed at a later stage.