### PR TITLE
Reduce memory usage of the becke weights

### DIFF
--- a/src/grid/becke.py
+++ b/src/grid/becke.py
@@ -151,9 +151,12 @@ class BeckeWeights:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             mu_n_p_p = p_p_n.transpose([2, 0, 1]) / atomic_dist
+        del p_p_n
         alpha = BeckeWeights._calculate_alpha(radii)
         v_pp = mu_n_p_p + alpha * (1 - mu_n_p_p ** 2)
+        del mu_n_p_p
         s_ab = 0.5 * (1 - BeckeWeights._switch_func(v_pp, order=order))
+        del v_pp
         # convert nan to 1
         s_ab[np.isnan(s_ab)] = 1
         # product up A_B, A_C, A_D ... along rows

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -45,7 +45,8 @@ class MolGrid(Grid):
                 # Becke weights are computed for "chunks" of grid points
                 # to counteract the scaling of the memory usage of the
                 # vectorized implementation of the Becke partitioning.
-                chunk_size = max(1, (100 * self._size) // self._coors.shape[0] ** 2)
+                chunk_size = max(1, (10 * self._size) // self._coors.shape[0] ** 2)
+                print(chunk_size, self._size)
                 self._aim_weights = np.concatenate(
                     [
                         BeckeWeights.generate_becke_weights(

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -46,14 +46,13 @@ class MolGrid(Grid):
                 # to counteract the scaling of the memory usage of the
                 # vectorized implementation of the Becke partitioning.
                 chunk_size = max(1, (10 * self._size) // self._coors.shape[0] ** 2)
-                print(chunk_size, self._size)
                 self._aim_weights = np.concatenate(
                     [
                         BeckeWeights.generate_becke_weights(
                             self._points[ibegin : ibegin + chunk_size],
                             radii,
                             self._coors,
-                            pt_ind=self._indices,
+                            pt_ind=(self._indices - ibegin).clip(min=0),
                         )
                         for ibegin in range(0, self._size, chunk_size)
                     ]

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -135,6 +135,24 @@ class TestMolGrid(TestCase):
             numbers[1] -= 1
     """
 
+    def test_integrate_hydrogen_8_1s(self):
+        """Test molecular integral in H2."""
+        x, y, z = np.meshgrid(*(3 * [[-0.5, 0.5]]))
+        centers = np.stack([x.ravel(), y.ravel(), z.ravel()], axis=1)
+        atgs = [
+            AtomicGrid.special_init(
+                self.rgrid, 0.5, scales=np.array([]), degs=np.array([17]), center=center
+            )
+            for center in centers
+        ]
+        mg = MolGrid(atgs, np.array([1] * len(centers)))
+        fn = 0
+        for center in centers:
+            dist = np.linalg.norm(center - mg.points, axis=1)
+            fn += np.exp(-2 * dist) / np.pi
+        occupation = mg.integrate(fn)
+        assert_almost_equal(occupation, len(centers), decimal=2)
+
     def test_molgrid_attrs_subgrid(self):
         """Test sub atomic grid attributes."""
         # numbers = np.array([6, 8], int)


### PR DESCRIPTION
Fixes #48 

These are the least invasive changes that fix the problem, i.e. by manually chunking before running the vectorized code and by adding a few del statements to Python's garbage collector.

The performance overhead on my test case is about 7%. Performance can be improved by using dask to parallelize over chunks but I did not want to add dask as a dependency.