### PR TITLE
1D Grid

### DIFF
--- a/src/grid/atomic_grid.py
+++ b/src/grid/atomic_grid.py
@@ -226,9 +226,13 @@ class AtomicGrid(Grid):
             raise TypeError(
                 f"Argument rgrid is not an instance of OneDGrid, got {type(rgrid)}."
             )
-        if rgrid.domain[0] < 0:
+        if rgrid.domain is not None and rgrid.domain[0] < 0:
             raise TypeError(
                 f"Argument rgrid should have a positive domain, got {rgrid.domain}"
+            )
+        elif np.min(rgrid.points) < 0.0:
+            raise TypeError(
+                f"Smallest rgrid.points is negative, got {np.min(rgrid.points)}"
             )
         if not isinstance(center, np.ndarray):
             raise TypeError(

--- a/src/grid/atomic_grid.py
+++ b/src/grid/atomic_grid.py
@@ -18,7 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """Module for generating Atomic Grid."""
-from grid.basegrid import AngularGrid, Grid, RadialGrid
+from grid.basegrid import AngularGrid, Grid, OneDGrid
 from grid.lebedev import generate_lebedev_grid, match_degree, size_to_degree
 
 import numpy as np
@@ -42,8 +42,8 @@ class AtomicGrid(Grid):
 
         Parameters
         ----------
-        rgrid : RadialGrid
-            Radial grid
+        rgrid : OneDGrid
+            A 1D grid with positive domain representing the radial component of grid.
         degs : np.ndarray(N, dtype=int) or list, keyword-only argument
             Different degree value for each radial point
         nums : np.ndarray(N, dtype=int) or list, keyword-only argument
@@ -222,9 +222,13 @@ class AtomicGrid(Grid):
         ValueError
             ``center`` needs to be an instance of ``np.ndarray`` class.
         """
-        if not isinstance(rgrid, RadialGrid):
+        if not isinstance(rgrid, OneDGrid):
             raise TypeError(
-                f"Argument rgrid is not an instance of RadialGrid, got {type(rgrid)}."
+                f"Argument rgrid is not an instance of OneDGrid, got {type(rgrid)}."
+            )
+        if rgrid.domain[0] < 0:
+            raise TypeError(
+                f"Argument rgrid should have a positive domain, got {rgrid.domain}"
             )
         if not isinstance(center, np.ndarray):
             raise TypeError(

--- a/src/grid/basegrid.py
+++ b/src/grid/basegrid.py
@@ -185,12 +185,12 @@ class OneDGrid(Grid):
                     f"domain should be an ascending tuple of length 2. domain={domain}"
                 )
             min_p = np.min(points)
-            if domain[0] >= min_p and abs(domain[0] - min_p) > 1e-6:
+            if domain[0] - 1e-7 >= min_p:
                 raise ValueError(
                     f"point coordinates should not be below domain! {min_p < domain[0]}"
                 )
             max_p = np.max(points)
-            if domain[1] <= max_p and abs(domain[1] - max_p) > 1e-6:
+            if domain[1] + 1e-7 <= max_p:
                 raise ValueError(
                     f"point coordinates should not be above domain! {domain[1] < max_p}"
                 )

--- a/src/grid/basegrid.py
+++ b/src/grid/basegrid.py
@@ -150,8 +150,78 @@ class SimpleAtomicGrid(Grid):
 
 
 class OneDGrid(Grid):
-    """PlaceHolder for 1dGrid object."""
+    """One-Dimensional Grid."""
 
+    def __init__(self, points, weights, domain=None):
+        r"""Construct grid.
 
-class RadialGrid(Grid):
-    """PlaceHolder for Radial Grid."""
+        Parameters
+        ----------
+        points : np.ndarray(N,)
+            A 1-D array of coordinates of :math:`N` points in one-dimension.
+        weights : np.ndarray(N,)
+            A 1-D array of integration weights of :math:`N` points in one-dimension.
+        domain : tuple(int, int), optional
+            The range of coordinate of points in ascending order.
+
+        """
+        # check points & weights
+        if points.ndim != 1:
+            raise ValueError(
+                f"Argument points should be a 1-D array. points.ndim={points.ndim}"
+            )
+        if weights.ndim != 1:
+            raise ValueError(
+                f"Argument weights should be a 1-D array. weights.ndim={weights.ndim}"
+            )
+        # assign domain
+        if domain is None:
+            domain = (np.min(points), np.max(points))
+        # check domain
+        if len(domain) != 2 or domain[0] > domain[1]:
+            raise ValueError(
+                f"domain should be an ascending tuple of length 2. domain={domain}"
+            )
+        min_p = np.min(points)
+        if domain[0] >= min_p and abs(domain[0] - min_p) > 1e-6:
+            raise ValueError(
+                f"point coordinates should not be below domain! {min_p < domain[0]}"
+            )
+        max_p = np.max(points)
+        if domain[1] <= max_p and abs(domain[1] - max_p) > 1e-6:
+            raise ValueError(
+                f"point coordinates should not be above domain! {domain[1] < max_p}"
+            )
+        super().__init__(points, weights)
+        self._domain = domain
+
+    @property
+    def domain(self):
+        """(int, int): the range of grid points."""
+        return self._domain
+
+    def __getitem__(self, index):
+        """Dunder method for index grid object and slicing.
+
+        Parameters
+        ----------
+        index : int or slice
+            index of slice object for selecting certain part of grid
+
+        Returns
+        -------
+        OneDGrid
+            Return a new grid instance with a subset of points.
+        """
+        if isinstance(index, int):
+            return self.__class__(
+                np.array([self.points[index]]),
+                np.array([self.weights[index]]),
+                self._domain,
+            )
+        else:
+            return self.__class__(
+                np.array(self.points[index]),
+                np.array(self.weights[index]),
+                self._domain,
+            )

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -58,7 +58,7 @@ def GaussLaguerre(npoints, alpha=0):
         raise ValueError(f"Alpha need to be bigger than -1, given {alpha}")
     points, weights = roots_genlaguerre(npoints, alpha)
     weights = weights * np.exp(points) * np.power(points, -alpha)
-    return OneDGrid(points, weights)
+    return OneDGrid(points, weights, (0, np.inf))
 
 
 def GaussLegendre(npoints):
@@ -79,7 +79,7 @@ def GaussLegendre(npoints):
 
     """
     points, weights = np.polynomial.legendre.leggauss(npoints)
-    return OneDGrid(points, weights)
+    return OneDGrid(points, weights, (-1, 1))
 
 
 def GaussChebyshev(npoints):
@@ -111,7 +111,7 @@ def GaussChebyshev(npoints):
     # weights are pi/n, all weights are the same
     points, weights = np.polynomial.chebyshev.chebgauss(npoints)
     weights = weights * np.sqrt(1 - np.power(points, 2))
-    return OneDGrid(points[::-1], weights)
+    return OneDGrid(points[::-1], weights, (-1, 1))
 
 
 def HortonLinear(npoints):

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -24,7 +24,7 @@ import warnings
 from abc import ABC, abstractmethod
 from numbers import Number
 
-from grid.basegrid import OneDGrid, RadialGrid
+from grid.basegrid import OneDGrid
 
 import numpy as np
 
@@ -58,12 +58,12 @@ class BaseTransform(ABC):
         Parameters
         ----------
         oned_grid : OneDGrid
-            one dimensional grid generated for integration purpose
+            An instance of 1D grid.
 
         Returns
         -------
-        RadialGrid
-            one dimensional grid spanning from (0, inf(certain number))
+        OneDGrid
+            Transformed 1D grid spanning a different domain.
 
         Raises
         ------
@@ -74,7 +74,8 @@ class BaseTransform(ABC):
             raise TypeError(f"Input grid is not OneDGrid, got {type(oned_grid)}")
         new_points = self.transform(oned_grid.points)
         new_weights = self.deriv(oned_grid.points) * oned_grid.weights
-        return RadialGrid(new_points, new_weights)
+        new_domain = self.transform(np.array(oned_grid.domain))
+        return OneDGrid(new_points, new_weights, new_domain)
 
     def _convert_inf(self, array, replace_inf=1e16):
         """Convert np.inf(float) to 1e16(float) in case of numerical failure.

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -74,7 +74,9 @@ class BaseTransform(ABC):
             raise TypeError(f"Input grid is not OneDGrid, got {type(oned_grid)}")
         new_points = self.transform(oned_grid.points)
         new_weights = self.deriv(oned_grid.points) * oned_grid.weights
-        new_domain = self.transform(np.array(oned_grid.domain))
+        new_domain = oned_grid.domain
+        if new_domain is not None:
+            new_domain = self.transform(np.array(oned_grid.domain))
         return OneDGrid(new_points, new_weights, new_domain)
 
     def _convert_inf(self, array, replace_inf=1e16):

--- a/src/grid/tests/test_atomic_grid.py
+++ b/src/grid/tests/test_atomic_grid.py
@@ -239,3 +239,9 @@ class TestAtomicGrid(TestCase):
             AtomicGrid(Grid(np.arange(1, 5, 1), np.ones(4)), degs=[2, 3, 4, 5])
         with self.assertRaises(TypeError):
             AtomicGrid(OneDGrid(np.arange(-2, 2, 1), np.ones(4)), degs=[2, 3, 4, 5])
+        with self.assertRaises(TypeError):
+            rgrid = OneDGrid(np.arange(1, 3, 1), np.ones(2), domain=(-1, 5))
+            AtomicGrid(rgrid, degs=[2])
+        with self.assertRaises(TypeError):
+            rgrid = OneDGrid(np.arange(-1, 1, 1), np.ones(2))
+            AtomicGrid(rgrid, degs=[2])

--- a/src/grid/tests/test_atomic_grid.py
+++ b/src/grid/tests/test_atomic_grid.py
@@ -18,10 +18,12 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """Test class for atomic grid."""
+
+
 from unittest import TestCase
 
 from grid.atomic_grid import AtomicGrid
-from grid.basegrid import AngularGrid, OneDGrid
+from grid.basegrid import AngularGrid, Grid, OneDGrid
 from grid.lebedev import generate_lebedev_grid
 
 import numpy as np
@@ -232,3 +234,8 @@ class TestAtomicGrid(TestCase):
             AtomicGrid(OneDGrid(np.arange(3), np.arange(3)), degs=[17], rotate=-1)
         with self.assertRaises(ValueError):
             AtomicGrid(OneDGrid(np.arange(3), np.arange(3)), degs=[17], rotate="asdfaf")
+        # error of radial grid
+        with self.assertRaises(TypeError):
+            AtomicGrid(Grid(np.arange(1, 5, 1), np.ones(4)), degs=[2, 3, 4, 5])
+        with self.assertRaises(TypeError):
+            AtomicGrid(OneDGrid(np.arange(-2, 2, 1), np.ones(4)), degs=[2, 3, 4, 5])

--- a/src/grid/tests/test_atomic_grid.py
+++ b/src/grid/tests/test_atomic_grid.py
@@ -40,45 +40,43 @@ class TestAtomicGrid(TestCase):
         """Normal initialization test."""
         radial_pts = np.arange(0.1, 1.1, 0.1)
         radial_wts = np.ones(10) * 0.1
-        radial_grid = RadialGrid(radial_pts, radial_wts)
+        rgrid = RadialGrid(radial_pts, radial_wts)
         rad = 0.5
         scales = np.array([0.5, 1, 1.5])
         degs = np.array([6, 14, 14, 6])
         # generate a proper instance without failing.
-        ag_ob = AtomicGrid.special_init(
-            radial_grid, radius=rad, scales=scales, degs=degs
-        )
+        ag_ob = AtomicGrid.special_init(rgrid, radius=rad, scales=scales, degs=degs)
         assert isinstance(ag_ob, AtomicGrid)
         assert len(ag_ob.indices) == 11
         assert ag_ob.l_max == 15
         ag_ob = AtomicGrid.special_init(
-            radial_grid, radius=rad, scales=np.array([]), degs=np.array([6])
+            rgrid, radius=rad, scales=np.array([]), degs=np.array([6])
         )
         assert isinstance(ag_ob, AtomicGrid)
         assert len(ag_ob.indices) == 11
-        ag_ob = AtomicGrid(radial_grid, nums=[110])
+        ag_ob = AtomicGrid(rgrid, nums=[110])
         assert ag_ob.l_max == 17
         assert_array_equal(ag_ob._rad_degs, np.ones(10) * 17)
         assert ag_ob.size == 110 * 10
         # new init AtomicGrid
-        ag_ob2 = AtomicGrid(radial_grid, degs=[17])
+        ag_ob2 = AtomicGrid(rgrid, degs=[17])
         assert ag_ob2.l_max == 17
         assert_array_equal(ag_ob2._rad_degs, np.ones(10) * 17)
         assert ag_ob2.size == 110 * 10
         assert isinstance(ag_ob.rad_grid, RadialGrid)
-        assert_allclose(ag_ob.rad_grid.points, radial_grid.points)
-        assert_allclose(ag_ob.rad_grid.weights, radial_grid.weights)
+        assert_allclose(ag_ob.rad_grid.points, rgrid.points)
+        assert_allclose(ag_ob.rad_grid.weights, rgrid.weights)
 
     def test_find_l_for_rad_list(self):
         """Test private method find_l_for_rad_list."""
         radial_pts = np.arange(0.1, 1.1, 0.1)
         radial_wts = np.ones(10) * 0.1
-        radial_grid = RadialGrid(radial_pts, radial_wts)
+        rgrid = RadialGrid(radial_pts, radial_wts)
         rad = 1
         scales = np.array([0.2, 0.4, 0.8])
         degs = np.array([3, 5, 7, 3])
         atomic_grid_degree = AtomicGrid._find_l_for_rad_list(
-            radial_grid.points, rad, scales, degs
+            rgrid.points, rad, scales, degs
         )
         assert_equal(atomic_grid_degree, [3, 3, 5, 5, 7, 7, 7, 7, 3, 3])
 

--- a/src/grid/tests/test_atomic_grid.py
+++ b/src/grid/tests/test_atomic_grid.py
@@ -21,7 +21,7 @@
 from unittest import TestCase
 
 from grid.atomic_grid import AtomicGrid
-from grid.basegrid import AngularGrid, RadialGrid
+from grid.basegrid import AngularGrid, OneDGrid
 from grid.lebedev import generate_lebedev_grid
 
 import numpy as np
@@ -40,7 +40,7 @@ class TestAtomicGrid(TestCase):
         """Normal initialization test."""
         radial_pts = np.arange(0.1, 1.1, 0.1)
         radial_wts = np.ones(10) * 0.1
-        rgrid = RadialGrid(radial_pts, radial_wts)
+        rgrid = OneDGrid(radial_pts, radial_wts)
         rad = 0.5
         scales = np.array([0.5, 1, 1.5])
         degs = np.array([6, 14, 14, 6])
@@ -63,7 +63,7 @@ class TestAtomicGrid(TestCase):
         assert ag_ob2.l_max == 17
         assert_array_equal(ag_ob2._rad_degs, np.ones(10) * 17)
         assert ag_ob2.size == 110 * 10
-        assert isinstance(ag_ob.rad_grid, RadialGrid)
+        assert isinstance(ag_ob.rad_grid, OneDGrid)
         assert_allclose(ag_ob.rad_grid.points, rgrid.points)
         assert_allclose(ag_ob.rad_grid.weights, rgrid.weights)
 
@@ -71,7 +71,7 @@ class TestAtomicGrid(TestCase):
         """Test private method find_l_for_rad_list."""
         radial_pts = np.arange(0.1, 1.1, 0.1)
         radial_wts = np.ones(10) * 0.1
-        rgrid = RadialGrid(radial_pts, radial_wts)
+        rgrid = OneDGrid(radial_pts, radial_wts)
         rad = 1
         scales = np.array([0.2, 0.4, 0.8])
         degs = np.array([3, 5, 7, 3])
@@ -99,7 +99,7 @@ class TestAtomicGrid(TestCase):
         # setup testing class
         rad_pts = np.array([0.1, 0.5, 1])
         rad_wts = np.array([0.3, 0.4, 0.3])
-        rad_grid = RadialGrid(rad_pts, rad_wts)
+        rad_grid = OneDGrid(rad_pts, rad_wts)
         degs = np.array([3, 5, 7])
         pts, wts, ind = AtomicGrid._generate_atomic_grid(rad_grid, degs)
         assert len(pts) == 46
@@ -120,7 +120,7 @@ class TestAtomicGrid(TestCase):
         """Test atomic grid center transilation."""
         rad_pts = np.array([0.1, 0.5, 1])
         rad_wts = np.array([0.3, 0.4, 0.3])
-        rad_grid = RadialGrid(rad_pts, rad_wts)
+        rad_grid = OneDGrid(rad_pts, rad_wts)
         degs = np.array([3, 5, 7])
         # origin center
         # randome center
@@ -135,7 +135,7 @@ class TestAtomicGrid(TestCase):
         """Test random rotation for atomic grid."""
         rad_pts = np.array([0.1, 0.5, 1])
         rad_wts = np.array([0.3, 0.4, 0.3])
-        rad_grid = RadialGrid(rad_pts, rad_wts)
+        rad_grid = OneDGrid(rad_pts, rad_wts)
         degs = [3, 5, 7]
         atgrid = AtomicGrid(rad_grid, degs=degs)
         # make sure True and 1 is not the same result
@@ -162,7 +162,7 @@ class TestAtomicGrid(TestCase):
         """Test angular grid get from get_shell_grid function."""
         rad_pts = np.array([0.1, 0.5, 1])
         rad_wts = np.array([0.3, 0.4, 0.3])
-        rad_grid = RadialGrid(rad_pts, rad_wts)
+        rad_grid = OneDGrid(rad_pts, rad_wts)
         degs = [3, 5, 7]
         atgrid = AtomicGrid(rad_grid, degs=degs)
         assert atgrid.n_shells == 3
@@ -191,25 +191,25 @@ class TestAtomicGrid(TestCase):
             )
         with self.assertRaises(ValueError):
             AtomicGrid.special_init(
-                RadialGrid(np.arange(3), np.arange(3)),
+                OneDGrid(np.arange(3), np.arange(3)),
                 radius=1.0,
                 scales=np.arange(2),
                 degs=np.arange(0),
             )
         with self.assertRaises(ValueError):
             AtomicGrid.special_init(
-                RadialGrid(np.arange(3), np.arange(3)),
+                OneDGrid(np.arange(3), np.arange(3)),
                 radius=1.0,
                 scales=np.arange(2),
                 degs=np.arange(4),
             )
         with self.assertRaises(ValueError):
             AtomicGrid._generate_atomic_grid(
-                RadialGrid(np.arange(3), np.arange(3)), np.arange(2)
+                OneDGrid(np.arange(3), np.arange(3)), np.arange(2)
             )
         with self.assertRaises(TypeError):
             AtomicGrid.special_init(
-                RadialGrid(np.arange(3), np.arange(3)),
+                OneDGrid(np.arange(3), np.arange(3)),
                 radius=1.0,
                 scales=np.array([0.3, 0.5, 0.7]),
                 degs=np.array([3, 5, 7, 5]),
@@ -217,7 +217,7 @@ class TestAtomicGrid(TestCase):
             )
         with self.assertRaises(ValueError):
             AtomicGrid.special_init(
-                RadialGrid(np.arange(3), np.arange(3)),
+                OneDGrid(np.arange(3), np.arange(3)),
                 radius=1.0,
                 scales=np.array([0.3, 0.5, 0.7]),
                 degs=np.array([3, 5, 7, 5]),
@@ -225,12 +225,10 @@ class TestAtomicGrid(TestCase):
             )
 
         with self.assertRaises(TypeError):
-            AtomicGrid(RadialGrid(np.arange(3), np.arange(3)), nums=110)
+            AtomicGrid(OneDGrid(np.arange(3), np.arange(3)), nums=110)
         with self.assertRaises(TypeError):
-            AtomicGrid(RadialGrid(np.arange(3), np.arange(3)), degs=17)
+            AtomicGrid(OneDGrid(np.arange(3), np.arange(3)), degs=17)
         with self.assertRaises(ValueError):
-            AtomicGrid(RadialGrid(np.arange(3), np.arange(3)), degs=[17], rotate=-1)
+            AtomicGrid(OneDGrid(np.arange(3), np.arange(3)), degs=[17], rotate=-1)
         with self.assertRaises(ValueError):
-            AtomicGrid(
-                RadialGrid(np.arange(3), np.arange(3)), degs=[17], rotate="asdfaf"
-            )
+            AtomicGrid(OneDGrid(np.arange(3), np.arange(3)), degs=[17], rotate="asdfaf")

--- a/src/grid/tests/test_grid.py
+++ b/src/grid/tests/test_grid.py
@@ -18,9 +18,11 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """Grid tests file."""
+
+
 from unittest import TestCase
 
-from grid.basegrid import Grid
+from grid.basegrid import Grid, OneDGrid
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -89,3 +91,44 @@ class TestGrid(TestCase):
             self.grid.integrate(5)
         with self.assertRaises(ValueError):
             self.grid.integrate(points)
+
+
+class TestOneDGrid(TestCase):
+    """OneDGrid test class."""
+
+    def test_errors_raises(self):
+        """Test errors raised."""
+        arr_1d = np.arange(10)
+        arr_2d = np.arange(20).reshape(4, 5)
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_2d, arr_1d)
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_2d)
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_1d, (0, 5))
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_1d, (1, 5))
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_1d, (1, 9))
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_1d, (0, 1, 2))
+        with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_1d, (9, 0))
+
+    def test_getitem(self):
+        """Test grid indexing."""
+        points = np.arange(20)
+        weights = np.arange(20) * 0.1
+        grid = OneDGrid(points, weights)
+        assert grid.size == 20
+        assert grid.domain == (0, 19)
+        subgrid = grid[0]
+        assert subgrid.size == 1
+        assert np.allclose(subgrid.points, points[0])
+        assert np.allclose(subgrid.weights, weights[0])
+        assert subgrid.domain == (0, 19)
+        subgrid = grid[3:7]
+        assert subgrid.size == 4
+        assert np.allclose(subgrid.points, points[3:7])
+        assert np.allclose(subgrid.weights, weights[3:7])
+        assert subgrid.domain == (0, 19)

--- a/src/grid/tests/test_grid.py
+++ b/src/grid/tests/test_grid.py
@@ -105,6 +105,8 @@ class TestOneDGrid(TestCase):
         with self.assertRaises(ValueError):
             OneDGrid(arr_1d, arr_2d)
         with self.assertRaises(ValueError):
+            OneDGrid(arr_1d, arr_1d[:, np.newaxis])
+        with self.assertRaises(ValueError):
             OneDGrid(arr_1d, arr_1d, (0, 5))
         with self.assertRaises(ValueError):
             OneDGrid(arr_1d, arr_1d, (1, 5))
@@ -121,14 +123,14 @@ class TestOneDGrid(TestCase):
         weights = np.arange(20) * 0.1
         grid = OneDGrid(points, weights)
         assert grid.size == 20
-        assert grid.domain == (0, 19)
+        assert grid.domain is None
         subgrid = grid[0]
         assert subgrid.size == 1
         assert np.allclose(subgrid.points, points[0])
         assert np.allclose(subgrid.weights, weights[0])
-        assert subgrid.domain == (0, 19)
+        assert subgrid.domain is None
         subgrid = grid[3:7]
         assert subgrid.size == 4
         assert np.allclose(subgrid.points, points[3:7])
         assert np.allclose(subgrid.weights, weights[3:7])
-        assert subgrid.domain == (0, 19)
+        assert subgrid.domain is None

--- a/src/grid/tests/test_interpolate.py
+++ b/src/grid/tests/test_interpolate.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """Interpolation tests file."""
+
 from unittest import TestCase
 
 from grid.atomic_grid import AtomicGrid
@@ -29,8 +30,9 @@ from grid.interpolate import (
     spline_with_atomic_grid,
     spline_with_sph_harms,
 )
+from grid.basegrid import OneDGrid
 from grid.lebedev import generate_lebedev_grid
-from grid.onedgrid import GaussLegendre, HortonLinear
+from grid.onedgrid import GaussLegendre
 from grid.rtransform import BeckeTF, IdentityRTransform
 
 import numpy as np
@@ -127,8 +129,8 @@ class TestInterpolate(TestCase):
 
     def test_spline_with_sph_harms(self):
         """Test spline projection the same as spherical harmonics."""
-        rad = IdentityRTransform().generate_radial(HortonLinear(10))
-        rad._points += 1
+        odg = OneDGrid(np.arange(10) + 1, np.ones(10))
+        rad = IdentityRTransform().generate_radial(odg)
         atgrid = AtomicGrid.special_init(rad, 1, scales=[], degs=[7])
         sph_coor = atgrid.convert_cart_to_sph()
         values = self.helper_func_power(atgrid.points)
@@ -174,8 +176,8 @@ class TestInterpolate(TestCase):
 
     def test_cubicspline_and_interp_mol(self):
         """Test cubicspline interpolation values."""
-        rad = IdentityRTransform().generate_radial(HortonLinear(10))
-        rad._points += 1
+        odg = OneDGrid(np.arange(10) + 1, np.ones(10))
+        rad = IdentityRTransform().generate_radial(odg)
         atgrid = AtomicGrid.special_init(rad, 1, scales=[], degs=[7])
         values = self.helper_func_power(atgrid.points)
         result = spline_with_atomic_grid(atgrid, values)
@@ -187,8 +189,8 @@ class TestInterpolate(TestCase):
 
     def test_cubicspline_and_interp(self):
         """Test cubicspline interpolation values."""
-        rad = IdentityRTransform().generate_radial(HortonLinear(10))
-        rad._points += 1
+        odg = OneDGrid(np.arange(10) + 1, np.ones(10))
+        rad = IdentityRTransform().generate_radial(odg)
         atgrid = AtomicGrid.special_init(rad, 1, scales=[], degs=[7])
         sph_coor = atgrid.convert_cart_to_sph()
         values = self.helper_func_power(atgrid.points)
@@ -226,8 +228,8 @@ class TestInterpolate(TestCase):
 
     def test_cubicspline_and_deriv(self):
         """Test spline for derivation."""
-        rad = IdentityRTransform().generate_radial(HortonLinear(10))
-        rad._points += 1
+        odg = OneDGrid(np.arange(10) + 1, np.ones(10))
+        rad = IdentityRTransform().generate_radial(odg)
         atgrid = AtomicGrid.special_init(rad, 1, scales=[], degs=[7])
         sph_coor = atgrid.convert_cart_to_sph()
         values = self.helper_func_power(atgrid.points)

--- a/src/grid/tests/test_interpolate.py
+++ b/src/grid/tests/test_interpolate.py
@@ -22,6 +22,7 @@
 from unittest import TestCase
 
 from grid.atomic_grid import AtomicGrid
+from grid.basegrid import OneDGrid
 from grid.interpolate import (
     _generate_sph_paras,
     generate_real_sph_harms,
@@ -30,7 +31,6 @@ from grid.interpolate import (
     spline_with_atomic_grid,
     spline_with_sph_harms,
 )
-from grid.basegrid import OneDGrid
 from grid.lebedev import generate_lebedev_grid
 from grid.onedgrid import GaussLegendre
 from grid.rtransform import BeckeTF, IdentityRTransform

--- a/src/grid/tests/test_radial.py
+++ b/src/grid/tests/test_radial.py
@@ -19,7 +19,7 @@
 # --
 """Radial grid test."""
 
-from grid.basegrid import RadialGrid
+from grid.basegrid import OneDGrid
 from grid.onedgrid import HortonLinear
 from grid.rtransform import ExpRTransform, PowerRTransform
 
@@ -32,7 +32,7 @@ def test_basics1():
     oned = HortonLinear(4)
     rtf = ExpRTransform(0.1, 1e1)
     grid = rtf.generate_radial(oned)
-    assert isinstance(grid, RadialGrid)
+    assert isinstance(grid, OneDGrid)
 
     assert grid.size == 4
     # assert grid.shape == (4,)
@@ -47,7 +47,7 @@ def test_basics2():
     oned = HortonLinear(100)
     rtf = ExpRTransform(1e-3, 1e1)
     grid = rtf.generate_radial(oned)
-    assert isinstance(grid, RadialGrid)
+    assert isinstance(grid, OneDGrid)
 
     assert grid.size == 100
     # assert grid.shape == (100,)
@@ -62,7 +62,7 @@ def test_integrate_gauss():
     oned = HortonLinear(100)
     rtf = PowerRTransform(0.0005, 1e1)
     grid = rtf.generate_radial(oned)
-    assert isinstance(grid, RadialGrid)
+    assert isinstance(grid, OneDGrid)
 
     y = np.exp(-0.5 * grid.points ** 2)
     # time 4 \pi and r^2 to accommodate old horton test


### PR DESCRIPTION
This PR simply removes `RadialGrid` placeholder and extends on `OneDGrid` (so that it wouldn't be just a placeholder) to be able to represent a radial grid as well.