### PR TITLE
Make MolGrid weights consistent with Grid class

### DIFF
--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -242,8 +242,6 @@ class MolGrid(Grid):
             s_ind = self._indices[index]
             f_ind = self._indices[index + 1]
             return SimpleAtomicGrid(
-                self.points[s_ind:f_ind],
-                self.weights[s_ind:f_ind] * self.aim_weights[s_ind:f_ind],
-                self._coors[index],
+                self.points[s_ind:f_ind], self.weights[s_ind:f_ind], self._coors[index]
             )
         return self._atomic_grids[index]


### PR DESCRIPTION
1. This makes weight attr contain the total integration weight.
2. MolGrid can now use integrate method of Grid class.
3. AtomicGrid weights are still stored in _atweights attr.