### PR TITLE
Improve docstring of grid base class and improve get_subgrid

### DIFF
--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -45,9 +45,9 @@ class MolGrid(Grid):
         # initialize these attributes
         self._coors = np.zeros((len(atomic_grids), 3))
         self._indices = np.zeros(len(atomic_grids) + 1, dtype=int)
-        self._size = np.sum([atomgrid.size for atomgrid in atomic_grids])
-        self._points = np.zeros((self._size, 3))
-        self._atweights = np.zeros(self._size)
+        size = np.sum([atomgrid.size for atomgrid in atomic_grids])
+        self._points = np.zeros((size, 3))
+        self._atweights = np.zeros(size)
         self._atomic_grids = atomic_grids if store else None
 
         for i, atom_grid in enumerate(atomic_grids):
@@ -63,10 +63,10 @@ class MolGrid(Grid):
             )
 
         elif isinstance(aim_weights, np.ndarray):
-            if aim_weights.size != self.size:
+            if aim_weights.size != size:
                 raise ValueError(
                     "aim_weights is not the same size as grid.\n"
-                    f"aim_weights.size: {aim_weights.size}, grid.size: {self.size}."
+                    f"aim_weights.size: {aim_weights.size}, grid.size: {size}."
                 )
             self._aim_weights = aim_weights
 

--- a/src/grid/tests/test_grid.py
+++ b/src/grid/tests/test_grid.py
@@ -33,19 +33,17 @@ class TestGrid(TestCase):
 
     def setUp(self):
         """Test setup function."""
-        points = np.linspace(-1, 1, 21)
-        weights = np.ones(21) * 0.1
-        self.grid = Grid(points, weights)
+        self._ref_points = np.linspace(-1, 1, 21)
+        self._ref_weights = np.ones(21) * 0.1
+        self.grid = Grid(self._ref_points, self._ref_weights)
 
     def test_init_grid(self):
         """Test Grid init."""
         # tests property
         assert isinstance(self.grid, Grid)
-        ref_pts = np.arange(-1, 1.1, 0.1)
-        ref_wts = np.ones(21) * 0.1
-        assert_allclose(self.grid.points, ref_pts, atol=1e-7)
-        assert_allclose(self.grid.weights, ref_wts)
-        assert self.grid.size == 21
+        assert_allclose(self.grid.points, self._ref_points, atol=1e-7)
+        assert_allclose(self.grid.weights, self._ref_weights)
+        assert self.grid.size == self._ref_weights.size
 
     def test_integrate(self):
         """Test Grid integral."""
@@ -62,35 +60,109 @@ class TestGrid(TestCase):
         """Test Grid index and slicing."""
         # test index
         grid_index = self.grid[10]
-        ref_grid = Grid(np.array([0]), np.array([0.1]))
+        ref_grid = Grid(self._ref_points[10:11], self._ref_weights[10:11])
         assert_allclose(grid_index.points, ref_grid.points)
         assert_allclose(grid_index.weights, ref_grid.weights)
         assert isinstance(grid_index, Grid)
         # test slice
-        ref_grid_slice = Grid(np.linspace(-1, 0, 11), np.ones(11) * 0.1)
+        ref_grid_slice = Grid(self._ref_points[:11], self._ref_weights[:11])
         grid_slice = self.grid[:11]
         assert_allclose(grid_slice.points, ref_grid_slice.points)
         assert_allclose(grid_slice.weights, ref_grid_slice.weights)
         assert isinstance(grid_slice, Grid)
         a = np.array([1, 3, 5])
         ref_smt_index = self.grid[a]
-        assert_allclose(ref_smt_index.points, np.array([-0.9, -0.7, -0.5]))
-        assert_allclose(ref_smt_index.weights, np.array([0.1, 0.1, 0.1]))
+        assert_allclose(ref_smt_index.points, self._ref_points[a])
+        assert_allclose(ref_smt_index.weights, self._ref_weights[a])
+
+    def test_get_subgrid(self):
+        """Test the creation of the subgrid with a normal radius."""
+        center = self.grid.points[3]
+        radius = 0.2
+        subgrid = self.grid.get_subgrid(center, radius)
+        # Just make sure we are testing with an actual subgrid with less (but
+        # not zero) points.
+        assert subgrid.size > 0
+        assert subgrid.size < self.grid.size
+        # Test that the subgrid contains the correct results.
+        assert subgrid.points.ndim == self.grid.points.ndim
+        assert subgrid.weights.ndim == self.grid.weights.ndim
+        assert_allclose(subgrid.points, self.grid.points[subgrid.indices])
+        assert_allclose(subgrid.weights, self.grid.weights[subgrid.indices])
+        if self._ref_points.ndim == 2:
+            assert (np.linalg.norm(subgrid.points - center, axis=1) <= radius).all()
+        else:
+            assert (abs(subgrid.points - center) <= radius).all()
+
+    def test_get_subgrid_radius_inf(self):
+        """Test the creation of the subgrid with an infinite radius."""
+        subgrid = self.grid.get_subgrid(self.grid.points[3], np.inf)
+        # Just make sure we are testing with a real subgrid
+        assert subgrid.size == self.grid.size
+        assert_allclose(subgrid.points, self.grid.points)
+        assert_allclose(subgrid.weights, self.grid.weights)
+        assert_allclose(subgrid.indices, np.arange(self.grid.size))
 
     def test_errors_raise(self):
         """Test errors raise."""
         # grid init
-        weights = np.ones(4)
-        points = np.arange(5)
         with self.assertRaises(ValueError):
-            Grid(points, weights)
+            Grid(self._ref_points, np.ones(len(self._ref_weights) + 1))
+        with self.assertRaises(ValueError):
+            Grid(self._ref_points.reshape(self.grid.size, 1, 1), self._ref_weights)
+        with self.assertRaises(ValueError):
+            Grid(self._ref_points, self._ref_weights.reshape(-1, 1))
         # integral
         with self.assertRaises(ValueError):
             self.grid.integrate()
         with self.assertRaises(TypeError):
             self.grid.integrate(5)
+        if self._ref_points.ndim == 2:
+            with self.assertRaises(ValueError):
+                self.grid.integrate(self._ref_points)
+        # get_subgrid
         with self.assertRaises(ValueError):
-            self.grid.integrate(points)
+            self.grid.get_subgrid(self._ref_points[0], -1)
+        with self.assertRaises(ValueError):
+            self.grid.get_subgrid(self._ref_points[0], -np.inf)
+        with self.assertRaises(ValueError):
+            self.grid.get_subgrid(self._ref_points[0], np.nan)
+        if self._ref_points.ndim == 2:
+            with self.assertRaises(ValueError):
+                self.grid.get_subgrid(np.zeros(self._ref_points.shape[1] + 1), 5.0)
+        else:
+            with self.assertRaises(ValueError):
+                self.grid.get_subgrid(np.zeros(2), 5.0)
+
+
+class TestGrid1D(TestGrid):
+    """Grid testcase class for 1D point arrays."""
+
+    def setUp(self):
+        """Test setup function."""
+        self._ref_points = np.linspace(-1, 1, 21).reshape(-1, 1)
+        self._ref_weights = np.ones(21) * 0.1
+        self.grid = Grid(self._ref_points, self._ref_weights)
+
+
+class TestGrid2D(TestGrid):
+    """Grid testcase class for 2D point arrays."""
+
+    def setUp(self):
+        """Test setup function."""
+        self._ref_points = np.array([np.linspace(-1, 1, 21)] * 2).T
+        self._ref_weights = np.ones(21) * 0.1
+        self.grid = Grid(self._ref_points, self._ref_weights)
+
+
+class TestGrid3D(TestGrid):
+    """Grid testcase class for 3D point arrays."""
+
+    def setUp(self):
+        """Test setup function."""
+        self._ref_points = np.array([np.linspace(-1, 1, 21)] * 3).T
+        self._ref_weights = np.ones(21) * 0.1
+        self.grid = Grid(self._ref_points, self._ref_weights)
 
 
 class TestSubGrid(TestCase):


### PR DESCRIPTION
A bunch of unit tests were added to make sure get_subgrid works as expected in various scenarios.

I've also remove self._size and the way it was used in MolGrid. Constructors of subclasses should not use or change attributes defined by the parent class.