### PR TITLE
Add extra line to unit tests of lebedev grids

### DIFF
--- a/src/grid/tests/test_lebedev_laikov.py
+++ b/src/grid/tests/test_lebedev_laikov.py
@@ -57,6 +57,7 @@ class TestLebedev(TestCase):
                 assert_allclose(grid.points[:, 0] @ grid.weights, 0, atol=1e-10)
                 assert_allclose(grid.points[:, 1] @ grid.weights, 0, atol=1e-10)
                 assert_allclose(grid.points[:, 2] @ grid.weights, 0, atol=1e-10)
+                assert grid.weights.min() > 0
             previous_npoint = npoint
 
     def test_match_degree(self):


### PR DESCRIPTION
@tczorro This is actually more an issue than a PR. It seems there is an error in the datafiles containing the Lebedev grids. I've added a corresponding line to the unit tests, which fails (appropriately). The problem is that some of the Lebedev quadrature weights in the data files are negative while they should be all positive. (Corresponding grids gave rather weird results when I was trying to use them). This is probably a glitch in the script used to generate these data files? Could you add this script to the data directory, such that we can take a closer look? Without it, it is difficult to see what went wrong and how to fix it. Thanks.

(I've used `.min()` so the failing assert shows the most negative weight.)