### PR TITLE
Build LEBEDEV_DEGREES from LEBEDEV_NPOINTS

### DIFF
--- a/src/grid/lebedev.py
+++ b/src/grid/lebedev.py
@@ -31,7 +31,7 @@ from importlib_resources import path
 
 import numpy as np
 
-
+# Lebedev dictionary for converting number of grid points (keys) to grid's degrees (values)
 LEBEDEV_NPOINTS = {
     6: 3,
     14: 5,
@@ -67,40 +67,8 @@ LEBEDEV_NPOINTS = {
     5810: 131,
 }
 
-LEBEDEV_DEGREES = {
-    3: 6,
-    5: 14,
-    7: 26,
-    9: 38,
-    11: 50,
-    13: 74,
-    15: 86,
-    17: 110,
-    19: 146,
-    21: 170,
-    23: 194,
-    25: 230,
-    27: 266,
-    29: 302,
-    31: 350,
-    35: 434,
-    41: 590,
-    47: 770,
-    53: 974,
-    59: 1202,
-    65: 1454,
-    71: 1730,
-    77: 2030,
-    83: 2354,
-    89: 2702,
-    95: 3074,
-    101: 3470,
-    107: 3890,
-    113: 4334,
-    119: 4802,
-    125: 5294,
-    131: 5810,
-}
+# Lebedev dictionary for converting grid's degrees (keys) to number of grid points (values)
+LEBEDEV_DEGREES = dict([(v, k) for k, v in LEBEDEV_NPOINTS.items()])
 
 
 def generate_lebedev_grid(*, degree=None, size=None):


### PR DESCRIPTION
This is a very minor change. Unless there is a specific reason to keep both dictionaries, I think it is less error-prone to build one from the other. Feel free to let me know what you think.
