### PR TITLE
Update AtomGrid

### DIFF
--- a/src/grid/atomgrid.py
+++ b/src/grid/atomgrid.py
@@ -107,28 +107,20 @@ class AtomGrid(Grid):
         self._size = self._weights.size
 
     @classmethod
-    def from_predefined(
-        cls,
-        atnum,
-        rgrid,
-        grid_type,
-        *_,
-        center=None,
-        rotate=False,
-    ):
+    def from_predefined(cls, rgrid, atnum, grid_type, *_, center=None, rotate=False):
         """High level to construct prefined atomic grid.
 
         Examples
         --------
         # construct an atomic grid for H with fine grid setting
-        >>> atgrid = AtomGrid.from_predefined(1, rgrid, "fine")
+        >>> atgrid = AtomGrid.from_predefined(rgrid,1,"fine")
 
         Parameters
         ----------
-        atnum : int
-            atomic number of atomic grid
         rgrid : RadialGrid
             points where sperical grids will be located
+        atnum : int
+            The atomic number corresponding to the grid.
         grid_type : str
             different accuracy for atomic grid
             include: 'coarse', 'medium', 'fine', 'veryfine', 'ultrafine', 'insane'

--- a/src/grid/atomgrid.py
+++ b/src/grid/atomgrid.py
@@ -209,7 +209,9 @@ class AtomGrid(Grid):
             else np.asarray(center, dtype=float)
         )
         cls._input_type_check(rgrid, center)
-        degrees = cls._generate_degree_from_radius(rgrid, radius, sectors_r, sectors_degree)
+        degrees = cls._generate_degree_from_radius(
+            rgrid, radius, sectors_r, sectors_degree
+        )
         return cls(rgrid, degrees=degrees, center=center, rotate=rotate)
 
     @property

--- a/src/grid/atomgrid.py
+++ b/src/grid/atomgrid.py
@@ -100,9 +100,9 @@ class AtomGrid(Grid):
             raise TypeError(f"degs is not type: np.array or list, got {type(degs)}")
         if len(degs) == 1:
             degs = np.ones(rgrid.size, dtype=int) * degs
-        self._rad_degs = degs
+        self._degs = degs
         self._points, self._weights, self._indices = self._generate_atomic_grid(
-            self._rgrid, self._rad_degs, rotate=self._rot
+            self._rgrid, self._degs, rotate=self._rot
         )
         self._size = self._weights.size
 
@@ -238,13 +238,13 @@ class AtomGrid(Grid):
 
     @property
     def n_shells(self):
-        """int: return the number of shells in radial points."""
-        return len(self._rad_degs)
+        """int: Number of shells in radial points."""
+        return len(self._degs)
 
     @property
     def l_max(self):
         """int: Largest angular degree L value in angular grids."""
-        return np.max(self._rad_degs)
+        return np.max(self._degs)
 
     def get_shell_grid(self, index, r_sq=True):
         """Get the spherical integral grid at radial point {index}.

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -194,9 +194,7 @@ class MolGrid(Grid):
         at_grids = []
         for i in range(len(atcoords)):
             at_grids.append(
-                AtomGrid(
-                    radial, size=[points_of_angular], center=atcoords[i], rotate=rotate
-                )
+                AtomGrid(radial, sizes=[points_of_angular], center=atcoords[i], rotate=rotate)
             )
         return cls(at_grids, aim_weights, atnums, store=store)
 

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -145,8 +145,9 @@ class MolGrid(Grid):
                     "not supported grid_type input\n"
                     f"got input type: {type(grid_type)}"
                 )
-            at_grid = AtomGrid.from_predefined(rad, atnums[i], gd_type, center=atcoords[i],
-                                               rotate=rotate)
+            at_grid = AtomGrid.from_predefined(
+                rad, atnums[i], gd_type, center=atcoords[i], rotate=rotate
+            )
             atomic_grids.append(at_grid)
         return cls(atomic_grids, aim_weights, atnums, store=store)
 
@@ -194,7 +195,9 @@ class MolGrid(Grid):
         at_grids = []
         for i in range(len(atcoords)):
             at_grids.append(
-                AtomGrid(radial, sizes=[points_of_angular], center=atcoords[i], rotate=rotate)
+                AtomGrid(
+                    radial, sizes=[points_of_angular], center=atcoords[i], rotate=rotate
+                )
             )
         return cls(at_grids, aim_weights, atnums, store=store)
 

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -145,9 +145,8 @@ class MolGrid(Grid):
                     "not supported grid_type input\n"
                     f"got input type: {type(grid_type)}"
                 )
-            at_grid = AtomGrid.from_predefined(
-                atnums[i], rad, gd_type, center=atcoords[i], rotate=rotate
-            )
+            at_grid = AtomGrid.from_predefined(rad, atnums[i], gd_type, center=atcoords[i],
+                                               rotate=rotate)
             atomic_grids.append(at_grid)
         return cls(atomic_grids, aim_weights, atnums, store=store)
 

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -51,21 +51,20 @@ class TestAtomGrid(TestCase):
         r_sectors = np.array([0.5, 1, 1.5])
         degs = np.array([6, 14, 14, 6])
         # generate a proper instance without failing.
-        ag_ob = AtomGrid.from_pruned(rgrid, radius=rad, r_sectors=r_sectors, degs=degs)
+        ag_ob = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=r_sectors, sectors_degree=degs)
         assert isinstance(ag_ob, AtomGrid)
         assert len(ag_ob.indices) == 11
         assert ag_ob.l_max == 15
-        ag_ob = AtomGrid.from_pruned(
-            rgrid, radius=rad, r_sectors=np.array([]), degs=np.array([6])
-        )
+        ag_ob = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=np.array([]),
+                                     sectors_degree=np.array([6]))
         assert isinstance(ag_ob, AtomGrid)
         assert len(ag_ob.indices) == 11
-        ag_ob = AtomGrid(rgrid, size=[110])
+        ag_ob = AtomGrid(rgrid, sizes=[110])
         assert ag_ob.l_max == 17
         assert_array_equal(ag_ob._degs, np.ones(10) * 17)
         assert ag_ob.size == 110 * 10
         # new init AtomGrid
-        ag_ob2 = AtomGrid(rgrid, degs=[17])
+        ag_ob2 = AtomGrid(rgrid, degrees=[17])
         assert ag_ob2.l_max == 17
         assert_array_equal(ag_ob2._degs, np.ones(10) * 17)
         assert ag_ob2.size == 110 * 10
@@ -153,13 +152,9 @@ class TestAtomGrid(TestCase):
         degs = np.array([3, 5, 7, 5])
         size = np.array([6, 14, 26, 14])
         # construct atomic grid with degs
-        atgrid1 = AtomGrid.from_pruned(
-            rgrid, radius=rad, r_sectors=r_sectors, degs=degs
-        )
+        atgrid1 = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=r_sectors, sectors_degree=degs)
         # construct atomic grid with size
-        atgrid2 = AtomGrid.from_pruned(
-            rgrid, radius=rad, r_sectors=r_sectors, size=size
-        )
+        atgrid2 = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=r_sectors, sectors_size=size)
         # test two grids are the same
         assert_equal(atgrid1.size, atgrid2.size)
         assert_allclose(atgrid1.points, atgrid2.points)
@@ -235,10 +230,10 @@ class TestAtomGrid(TestCase):
         rad_wts = np.array([0.3, 0.4, 0.3])
         rad_grid = OneDGrid(rad_pts, rad_wts)
         degs = [3, 5, 7]
-        atgrid = AtomGrid(rad_grid, degs=degs)
+        atgrid = AtomGrid(rad_grid, degrees=degs)
         # make sure True and 1 is not the same result
-        atgrid1 = AtomGrid(rad_grid, degs=degs, rotate=True)
-        atgrid2 = AtomGrid(rad_grid, degs=degs, rotate=1)
+        atgrid1 = AtomGrid(rad_grid, degrees=degs, rotate=True)
+        atgrid2 = AtomGrid(rad_grid, degrees=degs, rotate=1)
         # test diff points, same weights
         assert not np.allclose(atgrid.points, atgrid1.points)
         assert not np.allclose(atgrid.points, atgrid2.points)
@@ -268,7 +263,7 @@ class TestAtomGrid(TestCase):
         rad_wts = np.array([0.3, 0.4, 0.3])
         rad_grid = OneDGrid(rad_pts, rad_wts)
         degs = [3, 5, 7]
-        atgrid = AtomGrid(rad_grid, degs=degs)
+        atgrid = AtomGrid(rad_grid, degrees=degs)
         assert atgrid.n_shells == 3
         # grep shell with r^2
         for i in range(atgrid.n_shells):
@@ -293,7 +288,7 @@ class TestAtomGrid(TestCase):
         rad_wts = np.array([0.3, 0.4, 0.3])
         rad_grid = OneDGrid(rad_pts, rad_wts)
         center = np.random.rand(3)
-        atgrid = AtomGrid(rad_grid, degs=[7], center=center)
+        atgrid = AtomGrid(rad_grid, degrees=[7], center=center)
         points = np.random.rand(100, 3)
         calc_sph = atgrid.convert_cart_to_sph(points)
         # compute ref result
@@ -324,7 +319,7 @@ class TestAtomGrid(TestCase):
             end = np.random.rand() * 10 + 10
             tf = PowerRTransform(start, end)
             rad_grid = tf.transform_1d_grid(pts)
-            atgrid = AtomGrid(rad_grid, degs=list(LEBEDEV_DEGREES.keys()))
+            atgrid = AtomGrid(rad_grid, degrees=list(LEBEDEV_DEGREES.keys()))
             values = np.random.rand(len(LEBEDEV_DEGREES))
             pt_val = np.zeros(atgrid.size)
             for index, value in enumerate(values):
@@ -350,52 +345,38 @@ class TestAtomGrid(TestCase):
     def test_error_raises(self):
         """Tests for error raises."""
         with self.assertRaises(TypeError):
-            AtomGrid.from_pruned(
-                np.arange(3), 1.0, r_sectors=np.arange(2), degs=np.arange(3)
-            )
+            AtomGrid.from_pruned(np.arange(3), 1.0, sectors_r=np.arange(2),
+                                 sectors_degree=np.arange(3))
         with self.assertRaises(ValueError):
-            AtomGrid.from_pruned(
-                OneDGrid(np.arange(3), np.arange(3)),
-                radius=1.0,
-                r_sectors=np.arange(2),
-                degs=np.arange(0),
-            )
+            AtomGrid.from_pruned(OneDGrid(np.arange(3), np.arange(3)), radius=1.0,
+                                 sectors_r=np.arange(2), sectors_degree=np.arange(0))
         with self.assertRaises(ValueError):
-            AtomGrid.from_pruned(
-                OneDGrid(np.arange(3), np.arange(3)),
-                radius=1.0,
-                r_sectors=np.arange(2),
-                degs=np.arange(4),
-            )
+            AtomGrid.from_pruned(OneDGrid(np.arange(3), np.arange(3)), radius=1.0,
+                                 sectors_r=np.arange(2), sectors_degree=np.arange(4))
         with self.assertRaises(ValueError):
-            AtomGrid._generate_atomic_grid(
-                OneDGrid(np.arange(3), np.arange(3)), np.arange(2)
-            )
+            AtomGrid._generate_atomic_grid(OneDGrid(np.arange(3), np.arange(3)), np.arange(2))
         with self.assertRaises(ValueError):
-            AtomGrid.from_pruned(
-                OneDGrid(np.arange(3), np.arange(3)),
-                radius=1.0,
-                r_sectors=np.array([0.3, 0.5, 0.7]),
-                degs=np.array([3, 5, 7, 5]),
-                center=np.array([0, 0, 0, 0]),
-            )
+            AtomGrid.from_pruned(OneDGrid(np.arange(3), np.arange(3)), radius=1.0,
+                                 sectors_r=np.array([0.3, 0.5, 0.7]),
+                                 sectors_degree=np.array([3, 5, 7, 5]),
+                                 center=np.array([0, 0, 0, 0]))
 
         with self.assertRaises(TypeError):
-            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), size=110)
+            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), sizes=110)
         with self.assertRaises(TypeError):
-            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degs=17)
+            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degrees=17)
         with self.assertRaises(ValueError):
-            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degs=[17], rotate=-1)
+            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degrees=[17], rotate=-1)
         with self.assertRaises(TypeError):
-            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degs=[17], rotate="asdfaf")
+            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degrees=[17], rotate="asdfaf")
         # error of radial grid
         with self.assertRaises(TypeError):
-            AtomGrid(Grid(np.arange(1, 5, 1), np.ones(4)), degs=[2, 3, 4, 5])
+            AtomGrid(Grid(np.arange(1, 5, 1), np.ones(4)), degrees=[2, 3, 4, 5])
         with self.assertRaises(TypeError):
-            AtomGrid(OneDGrid(np.arange(-2, 2, 1), np.ones(4)), degs=[2, 3, 4, 5])
+            AtomGrid(OneDGrid(np.arange(-2, 2, 1), np.ones(4)), degrees=[2, 3, 4, 5])
         with self.assertRaises(TypeError):
             rgrid = OneDGrid(np.arange(1, 3, 1), np.ones(2), domain=(-1, 5))
-            AtomGrid(rgrid, degs=[2])
+            AtomGrid(rgrid, degrees=[2])
         with self.assertRaises(TypeError):
             rgrid = OneDGrid(np.arange(-1, 1, 1), np.ones(2))
-            AtomGrid(rgrid, degs=[2])
+            AtomGrid(rgrid, degrees=[2])

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -62,12 +62,12 @@ class TestAtomGrid(TestCase):
         assert len(ag_ob.indices) == 11
         ag_ob = AtomGrid(rgrid, size=[110])
         assert ag_ob.l_max == 17
-        assert_array_equal(ag_ob._rad_degs, np.ones(10) * 17)
+        assert_array_equal(ag_ob._degs, np.ones(10) * 17)
         assert ag_ob.size == 110 * 10
         # new init AtomGrid
         ag_ob2 = AtomGrid(rgrid, degs=[17])
         assert ag_ob2.l_max == 17
-        assert_array_equal(ag_ob2._rad_degs, np.ones(10) * 17)
+        assert_array_equal(ag_ob2._degs, np.ones(10) * 17)
         assert ag_ob2.size == 110 * 10
         assert isinstance(ag_ob.rgrid, OneDGrid)
         assert_allclose(ag_ob.rgrid.points, rgrid.points)

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -79,7 +79,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(20)
         tf = PowerRTransform(7.0879993828935345e-06, 16.05937640019924)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_predefined(1, rad_grid, "coarse")
+        atgrid = AtomGrid.from_predefined(rad_grid, 1, "coarse")
         # 604 points for coarse H atom
         assert_equal(atgrid.size, 604)
         assert_almost_equal(
@@ -91,7 +91,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(24)
         tf = PowerRTransform(3.69705074304963e-06, 19.279558946793685)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_predefined(1, rad_grid, "medium")
+        atgrid = AtomGrid.from_predefined(rad_grid, 1, "medium")
         # 928 points for coarse H atom
         assert_equal(atgrid.size, 928)
         assert_almost_equal(
@@ -102,7 +102,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(34)
         tf = PowerRTransform(2.577533167224667e-07, 16.276983371222354)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_predefined(1, rad_grid, "fine")
+        atgrid = AtomGrid.from_predefined(rad_grid, 1, "fine")
         # 1984 points for coarse H atom
         assert_equal(atgrid.size, 1984)
         assert_almost_equal(
@@ -113,7 +113,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(41)
         tf = PowerRTransform(1.1774580743206259e-07, 20.140888089596444)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_predefined(1, rad_grid, "veryfine")
+        atgrid = AtomGrid.from_predefined(rad_grid, 1, "veryfine")
         # 3154 points for coarse H atom
         assert_equal(atgrid.size, 3154)
         assert_almost_equal(
@@ -124,7 +124,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(49)
         tf = PowerRTransform(4.883104847991021e-08, 21.05456999309752)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_predefined(1, rad_grid, "ultrafine")
+        atgrid = AtomGrid.from_predefined(rad_grid, 1, "ultrafine")
         # 4546 points for coarse H atom
         assert_equal(atgrid.size, 4546)
         assert_almost_equal(
@@ -135,7 +135,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(59)
         tf = PowerRTransform(1.9221827244049134e-08, 21.413278983919113)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_predefined(1, rad_grid, "insane")
+        atgrid = AtomGrid.from_predefined(rad_grid, 1, "insane")
         # 6622 points for coarse H atom
         assert_equal(atgrid.size, 6622)
         assert_almost_equal(

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -51,12 +51,15 @@ class TestAtomGrid(TestCase):
         r_sectors = np.array([0.5, 1, 1.5])
         degs = np.array([6, 14, 14, 6])
         # generate a proper instance without failing.
-        ag_ob = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=r_sectors, sectors_degree=degs)
+        ag_ob = AtomGrid.from_pruned(
+            rgrid, radius=rad, sectors_r=r_sectors, sectors_degree=degs
+        )
         assert isinstance(ag_ob, AtomGrid)
         assert len(ag_ob.indices) == 11
         assert ag_ob.l_max == 15
-        ag_ob = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=np.array([]),
-                                     sectors_degree=np.array([6]))
+        ag_ob = AtomGrid.from_pruned(
+            rgrid, radius=rad, sectors_r=np.array([]), sectors_degree=np.array([6])
+        )
         assert isinstance(ag_ob, AtomGrid)
         assert len(ag_ob.indices) == 11
         ag_ob = AtomGrid(rgrid, sizes=[110])
@@ -152,9 +155,13 @@ class TestAtomGrid(TestCase):
         degs = np.array([3, 5, 7, 5])
         size = np.array([6, 14, 26, 14])
         # construct atomic grid with degs
-        atgrid1 = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=r_sectors, sectors_degree=degs)
+        atgrid1 = AtomGrid.from_pruned(
+            rgrid, radius=rad, sectors_r=r_sectors, sectors_degree=degs
+        )
         # construct atomic grid with size
-        atgrid2 = AtomGrid.from_pruned(rgrid, radius=rad, sectors_r=r_sectors, sectors_size=size)
+        atgrid2 = AtomGrid.from_pruned(
+            rgrid, radius=rad, sectors_r=r_sectors, sectors_size=size
+        )
         # test two grids are the same
         assert_equal(atgrid1.size, atgrid2.size)
         assert_allclose(atgrid1.points, atgrid2.points)
@@ -345,21 +352,35 @@ class TestAtomGrid(TestCase):
     def test_error_raises(self):
         """Tests for error raises."""
         with self.assertRaises(TypeError):
-            AtomGrid.from_pruned(np.arange(3), 1.0, sectors_r=np.arange(2),
-                                 sectors_degree=np.arange(3))
+            AtomGrid.from_pruned(
+                np.arange(3), 1.0, sectors_r=np.arange(2), sectors_degree=np.arange(3)
+            )
         with self.assertRaises(ValueError):
-            AtomGrid.from_pruned(OneDGrid(np.arange(3), np.arange(3)), radius=1.0,
-                                 sectors_r=np.arange(2), sectors_degree=np.arange(0))
+            AtomGrid.from_pruned(
+                OneDGrid(np.arange(3), np.arange(3)),
+                radius=1.0,
+                sectors_r=np.arange(2),
+                sectors_degree=np.arange(0),
+            )
         with self.assertRaises(ValueError):
-            AtomGrid.from_pruned(OneDGrid(np.arange(3), np.arange(3)), radius=1.0,
-                                 sectors_r=np.arange(2), sectors_degree=np.arange(4))
+            AtomGrid.from_pruned(
+                OneDGrid(np.arange(3), np.arange(3)),
+                radius=1.0,
+                sectors_r=np.arange(2),
+                sectors_degree=np.arange(4),
+            )
         with self.assertRaises(ValueError):
-            AtomGrid._generate_atomic_grid(OneDGrid(np.arange(3), np.arange(3)), np.arange(2))
+            AtomGrid._generate_atomic_grid(
+                OneDGrid(np.arange(3), np.arange(3)), np.arange(2)
+            )
         with self.assertRaises(ValueError):
-            AtomGrid.from_pruned(OneDGrid(np.arange(3), np.arange(3)), radius=1.0,
-                                 sectors_r=np.array([0.3, 0.5, 0.7]),
-                                 sectors_degree=np.array([3, 5, 7, 5]),
-                                 center=np.array([0, 0, 0, 0]))
+            AtomGrid.from_pruned(
+                OneDGrid(np.arange(3), np.arange(3)),
+                radius=1.0,
+                sectors_r=np.array([0.3, 0.5, 0.7]),
+                sectors_degree=np.array([3, 5, 7, 5]),
+                center=np.array([0, 0, 0, 0]),
+            )
 
         with self.assertRaises(TypeError):
             AtomGrid(OneDGrid(np.arange(3), np.arange(3)), sizes=110)
@@ -368,7 +389,9 @@ class TestAtomGrid(TestCase):
         with self.assertRaises(ValueError):
             AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degrees=[17], rotate=-1)
         with self.assertRaises(TypeError):
-            AtomGrid(OneDGrid(np.arange(3), np.arange(3)), degrees=[17], rotate="asdfaf")
+            AtomGrid(
+                OneDGrid(np.arange(3), np.arange(3)), degrees=[17], rotate="asdfaf"
+            )
         # error of radial grid
         with self.assertRaises(TypeError):
             AtomGrid(Grid(np.arange(1, 5, 1), np.ones(4)), degrees=[2, 3, 4, 5])

--- a/src/grid/tests/test_interpolate.py
+++ b/src/grid/tests/test_interpolate.py
@@ -131,7 +131,7 @@ class TestInterpolate(TestCase):
         """Test spline projection the same as spherical harmonics."""
         odg = OneDGrid(np.arange(10) + 1, np.ones(10), (0, np.inf))
         rad = IdentityRTransform().transform_1d_grid(odg)
-        atgrid = AtomGrid.from_pruned(rad, 1, r_sectors=[], degs=[7])
+        atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         sph_coor = atgrid.convert_cart_to_sph()
         values = self.helper_func_power(atgrid.points)
         l_max = atgrid.l_max // 2
@@ -158,7 +158,7 @@ class TestInterpolate(TestCase):
         oned = GaussLegendre(30)
         btf = BeckeTF(0.0001, 1.5)
         rad = btf.transform_1d_grid(oned)
-        atgrid = AtomGrid.from_pruned(rad, 1, r_sectors=[], degs=[7])
+        atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         value_array = self.helper_func_gauss(atgrid.points)
         result = spline_with_atomic_grid(atgrid, value_array)
         # random test points on gauss function
@@ -178,7 +178,7 @@ class TestInterpolate(TestCase):
         """Test cubicspline interpolation values."""
         odg = OneDGrid(np.arange(10) + 1, np.ones(10), (0, np.inf))
         rad = IdentityRTransform().transform_1d_grid(odg)
-        atgrid = AtomGrid.from_pruned(rad, 1, r_sectors=[], degs=[7])
+        atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         values = self.helper_func_power(atgrid.points)
         result = spline_with_atomic_grid(atgrid, values)
         sph_coor = atgrid.convert_cart_to_sph()
@@ -191,7 +191,7 @@ class TestInterpolate(TestCase):
         """Test cubicspline interpolation values."""
         odg = OneDGrid(np.arange(10) + 1, np.ones(10), (0, np.inf))
         rad = IdentityRTransform().transform_1d_grid(odg)
-        atgrid = AtomGrid.from_pruned(rad, 1, r_sectors=[], degs=[7])
+        atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         sph_coor = atgrid.convert_cart_to_sph()
         values = self.helper_func_power(atgrid.points)
         l_max = atgrid.l_max // 2
@@ -230,7 +230,7 @@ class TestInterpolate(TestCase):
         """Test spline for derivation."""
         odg = OneDGrid(np.arange(10) + 1, np.ones(10), (0, np.inf))
         rad = IdentityRTransform().transform_1d_grid(odg)
-        atgrid = AtomGrid.from_pruned(rad, 1, r_sectors=[], degs=[7])
+        atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         sph_coor = atgrid.convert_cart_to_sph()
         values = self.helper_func_power(atgrid.points)
         l_max = atgrid.l_max // 2

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -49,8 +49,13 @@ class TestMolGrid(TestCase):
         # rgrid = BeckeTF.transform_grid(oned, 0.001, 0.5)[0]
         # rtf = ExpRTransform(1e-3, 1e1, 100)
         # rgrid = RadialGrid(rtf)
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates)
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates,
+        )
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1], becke, np.array([1]))
         # mg = BeckeMolGrid(coordinates, numbers, None, (rgrid, 110), random_rotate=False)
@@ -111,9 +116,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(rad2, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_predefined(rad2, numbers[1], "veryfine", center=coordinates[1])
-        atgrid3 = AtomGrid.from_predefined(rad2, numbers[2], "medium", center=coordinates[2])
+        atgrid1 = AtomGrid.from_predefined(
+            rad2, numbers[0], "fine", center=coordinates[0]
+        )
+        atgrid2 = AtomGrid.from_predefined(
+            rad2, numbers[1], "veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_predefined(
+            rad2, numbers[2], "medium", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -129,9 +140,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(rad3, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_predefined(rad3, numbers[1], "veryfine", center=coordinates[1])
-        atgrid3 = AtomGrid.from_predefined(rad3, numbers[2], "fine", center=coordinates[2])
+        atgrid1 = AtomGrid.from_predefined(
+            rad3, numbers[0], "fine", center=coordinates[0]
+        )
+        atgrid2 = AtomGrid.from_predefined(
+            rad3, numbers[1], "veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_predefined(
+            rad3, numbers[2], "fine", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -164,9 +181,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(rad1, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_predefined(rad2, numbers[1], "veryfine", center=coordinates[1])
-        atgrid3 = AtomGrid.from_predefined(rad3, numbers[2], "fine", center=coordinates[2])
+        atgrid1 = AtomGrid.from_predefined(
+            rad1, numbers[0], "fine", center=coordinates[0]
+        )
+        atgrid2 = AtomGrid.from_predefined(
+            rad2, numbers[1], "veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_predefined(
+            rad3, numbers[2], "fine", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -187,9 +210,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(rad1, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_predefined(rad3, numbers[1], "veryfine", center=coordinates[1])
-        atgrid3 = AtomGrid.from_predefined(rad1, numbers[2], "fine", center=coordinates[2])
+        atgrid1 = AtomGrid.from_predefined(
+            rad1, numbers[0], "fine", center=coordinates[0]
+        )
+        atgrid2 = AtomGrid.from_predefined(
+            rad3, numbers[1], "veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_predefined(
+            rad1, numbers[2], "fine", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -197,10 +226,20 @@ class TestMolGrid(TestCase):
     def test_integrate_hydrogen_pair_1s(self):
         """Test molecular integral in H2."""
         coordinates = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[1])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[1],
+        )
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2], becke, np.array([1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
@@ -214,12 +253,27 @@ class TestMolGrid(TestCase):
         coordinates = np.array(
             [[0.0, 0.0, -0.5], [0.0, 0.0, 0.5], [0.0, 0.5, 0.0]], float
         )
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[1])
-        atg3 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[2])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[1],
+        )
+        atg3 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[2],
+        )
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2, atg3], becke, np.array([1, 1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
@@ -250,8 +304,13 @@ class TestMolGrid(TestCase):
         x, y, z = np.meshgrid(*(3 * [[-0.5, 0.5]]))
         centers = np.stack([x.ravel(), y.ravel(), z.ravel()], axis=1)
         atgs = [
-            AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                 sectors_degree=np.array([17]), center=center)
+            AtomGrid.from_pruned(
+                self.rgrid,
+                0.5,
+                sectors_r=np.array([]),
+                sectors_degree=np.array([17]),
+                center=center,
+            )
             for center in centers
         ]
 
@@ -268,10 +327,20 @@ class TestMolGrid(TestCase):
         """Test sub atomic grid attributes."""
         # numbers = np.array([6, 8], int)
         coordinates = np.array([[0.0, 0.2, -0.5], [0.1, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(self.rgrid, 1.228, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.945, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[1])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            1.228,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.945,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[1],
+        )
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2], becke, np.array([6, 8]), store=True)
         # mg = BeckeMolGrid(coordinates, numbers, None, (rgrid, 110), mode='keep')
@@ -301,10 +370,20 @@ class TestMolGrid(TestCase):
         """Test MolGrid attributes."""
         # numbers = np.array([6, 8], int)
         coordinates = np.array([[0.0, 0.2, -0.5], [0.1, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(self.rgrid, 1.228, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.945, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[1])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            1.228,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.945,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[1],
+        )
 
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2], becke, np.array([6, 8]), store=True)
@@ -339,10 +418,20 @@ class TestMolGrid(TestCase):
     def test_different_aim_weights_h2(self):
         """Test different aim_weights for molgrid."""
         coordinates = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[1])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[1],
+        )
         # use an array as aim_weights
         mg = MolGrid([atg1, atg2], np.ones(22000), np.array([1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
@@ -357,18 +446,33 @@ class TestMolGrid(TestCase):
         coors = np.array([[0, 0, -0.5], [0, 0, 0.5]])
         becke = BeckeWeights(order=3)
         mol_grid = MolGrid.horton_molgrid(coors, nums, self.rgrid, 110, becke)
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coors[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coors[1])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coors[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coors[1],
+        )
         ref_grid = MolGrid([atg1, atg2], becke, nums, store=True)
         assert_allclose(ref_grid.points, mol_grid.points)
         assert_allclose(ref_grid.weights, mol_grid.weights)
 
     def test_raise_errors(self):
         """Test molgrid errors raise."""
-        atg = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                   sectors_degree=np.array([17]), center=np.array([0.0, 0.0, 0.0]))
+        atg = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=np.array([0.0, 0.0, 0.0]),
+        )
 
         # errors of aim_weight
         with self.assertRaises(TypeError):
@@ -433,8 +537,13 @@ class TestMolGrid(TestCase):
         coords = np.array([0.0, 0.0, 0.0])
 
         # initialize MolGrid with atomic grid
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coords)
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coords,
+        )
         grid = MolGrid([atg1], BeckeWeights(), np.array([1]), store=False)
         fn = np.exp(-2 * np.linalg.norm(grid.points, axis=-1))
         assert_allclose(grid.integrate(fn), np.pi)
@@ -500,8 +609,13 @@ class TestMolGrid(TestCase):
         tf = ExpRTransform(1e-5, 2e1)
         rgrid = tf.transform_1d_grid(pts)
         coordinates = np.array([0.0, 0.0, -0.5])
-        atg1 = AtomGrid.from_pruned(rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates)
+        atg1 = AtomGrid.from_pruned(
+            rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates,
+        )
         mg = MolGrid([atg1], HirshfeldWeights(), np.array([7]))
         dist0 = np.sqrt(((coordinates - mg.points) ** 2).sum(axis=1))
         fn = np.exp(-2 * dist0) / np.pi
@@ -511,10 +625,20 @@ class TestMolGrid(TestCase):
     def test_integrate_hirshfeld_weights_pair_1s(self):
         """Test molecular integral in H2."""
         coordinates = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]])
-        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[0])
-        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
-                                    sectors_degree=np.array([17]), center=coordinates[1])
+        atg1 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[0],
+        )
+        atg2 = AtomGrid.from_pruned(
+            self.rgrid,
+            0.5,
+            sectors_r=np.array([]),
+            sectors_degree=np.array([17]),
+            center=coordinates[1],
+        )
         mg = MolGrid([atg1, atg2], HirshfeldWeights(), np.array([1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
         dist1 = np.sqrt(((coordinates[1] - mg.points) ** 2).sum(axis=1))

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -116,15 +116,9 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(
-            numbers[0], rad2, "fine", center=coordinates[0]
-        )
-        atgrid2 = AtomGrid.from_predefined(
-            numbers[1], rad2, "veryfine", center=coordinates[1]
-        )
-        atgrid3 = AtomGrid.from_predefined(
-            numbers[2], rad2, "medium", center=coordinates[2]
-        )
+        atgrid1 = AtomGrid.from_predefined(rad2, numbers[0], "fine", center=coordinates[0])
+        atgrid2 = AtomGrid.from_predefined(rad2, numbers[1], "veryfine", center=coordinates[1])
+        atgrid3 = AtomGrid.from_predefined(rad2, numbers[2], "medium", center=coordinates[2])
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -140,15 +134,9 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(
-            numbers[0], rad3, "fine", center=coordinates[0]
-        )
-        atgrid2 = AtomGrid.from_predefined(
-            numbers[1], rad3, "veryfine", center=coordinates[1]
-        )
-        atgrid3 = AtomGrid.from_predefined(
-            numbers[2], rad3, "fine", center=coordinates[2]
-        )
+        atgrid1 = AtomGrid.from_predefined(rad3, numbers[0], "fine", center=coordinates[0])
+        atgrid2 = AtomGrid.from_predefined(rad3, numbers[1], "veryfine", center=coordinates[1])
+        atgrid3 = AtomGrid.from_predefined(rad3, numbers[2], "fine", center=coordinates[2])
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -181,15 +169,9 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(
-            numbers[0], rad1, "fine", center=coordinates[0]
-        )
-        atgrid2 = AtomGrid.from_predefined(
-            numbers[1], rad2, "veryfine", center=coordinates[1]
-        )
-        atgrid3 = AtomGrid.from_predefined(
-            numbers[2], rad3, "fine", center=coordinates[2]
-        )
+        atgrid1 = AtomGrid.from_predefined(rad1, numbers[0], "fine", center=coordinates[0])
+        atgrid2 = AtomGrid.from_predefined(rad2, numbers[1], "veryfine", center=coordinates[1])
+        atgrid3 = AtomGrid.from_predefined(rad3, numbers[2], "fine", center=coordinates[2])
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -210,15 +192,9 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_predefined(
-            numbers[0], rad1, "fine", center=coordinates[0]
-        )
-        atgrid2 = AtomGrid.from_predefined(
-            numbers[1], rad3, "veryfine", center=coordinates[1]
-        )
-        atgrid3 = AtomGrid.from_predefined(
-            numbers[2], rad1, "fine", center=coordinates[2]
-        )
+        atgrid1 = AtomGrid.from_predefined(rad1, numbers[0], "fine", center=coordinates[0])
+        atgrid2 = AtomGrid.from_predefined(rad3, numbers[1], "veryfine", center=coordinates[1])
+        atgrid3 = AtomGrid.from_predefined(rad1, numbers[2], "fine", center=coordinates[2])
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -49,13 +49,8 @@ class TestMolGrid(TestCase):
         # rgrid = BeckeTF.transform_grid(oned, 0.001, 0.5)[0]
         # rtf = ExpRTransform(1e-3, 1e1, 100)
         # rgrid = RadialGrid(rtf)
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates,
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates)
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1], becke, np.array([1]))
         # mg = BeckeMolGrid(coordinates, numbers, None, (rgrid, 110), random_rotate=False)
@@ -202,20 +197,10 @@ class TestMolGrid(TestCase):
     def test_integrate_hydrogen_pair_1s(self):
         """Test molecular integral in H2."""
         coordinates = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[1],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[1])
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2], becke, np.array([1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
@@ -229,27 +214,12 @@ class TestMolGrid(TestCase):
         coordinates = np.array(
             [[0.0, 0.0, -0.5], [0.0, 0.0, 0.5], [0.0, 0.5, 0.0]], float
         )
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[1],
-        )
-        atg3 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[2],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[1])
+        atg3 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[2])
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2, atg3], becke, np.array([1, 1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
@@ -280,13 +250,8 @@ class TestMolGrid(TestCase):
         x, y, z = np.meshgrid(*(3 * [[-0.5, 0.5]]))
         centers = np.stack([x.ravel(), y.ravel(), z.ravel()], axis=1)
         atgs = [
-            AtomGrid.from_pruned(
-                self.rgrid,
-                0.5,
-                r_sectors=np.array([]),
-                degs=np.array([17]),
-                center=center,
-            )
+            AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                 sectors_degree=np.array([17]), center=center)
             for center in centers
         ]
 
@@ -303,20 +268,10 @@ class TestMolGrid(TestCase):
         """Test sub atomic grid attributes."""
         # numbers = np.array([6, 8], int)
         coordinates = np.array([[0.0, 0.2, -0.5], [0.1, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            1.228,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.945,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[1],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 1.228, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.945, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[1])
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2], becke, np.array([6, 8]), store=True)
         # mg = BeckeMolGrid(coordinates, numbers, None, (rgrid, 110), mode='keep')
@@ -346,20 +301,10 @@ class TestMolGrid(TestCase):
         """Test MolGrid attributes."""
         # numbers = np.array([6, 8], int)
         coordinates = np.array([[0.0, 0.2, -0.5], [0.1, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            1.228,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.945,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[1],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 1.228, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.945, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[1])
 
         becke = BeckeWeights(order=3)
         mg = MolGrid([atg1, atg2], becke, np.array([6, 8]), store=True)
@@ -394,20 +339,10 @@ class TestMolGrid(TestCase):
     def test_different_aim_weights_h2(self):
         """Test different aim_weights for molgrid."""
         coordinates = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]], float)
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[1],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[1])
         # use an array as aim_weights
         mg = MolGrid([atg1, atg2], np.ones(22000), np.array([1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
@@ -422,33 +357,18 @@ class TestMolGrid(TestCase):
         coors = np.array([[0, 0, -0.5], [0, 0, 0.5]])
         becke = BeckeWeights(order=3)
         mol_grid = MolGrid.horton_molgrid(coors, nums, self.rgrid, 110, becke)
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coors[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coors[1],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coors[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coors[1])
         ref_grid = MolGrid([atg1, atg2], becke, nums, store=True)
         assert_allclose(ref_grid.points, mol_grid.points)
         assert_allclose(ref_grid.weights, mol_grid.weights)
 
     def test_raise_errors(self):
         """Test molgrid errors raise."""
-        atg = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=np.array([0.0, 0.0, 0.0]),
-        )
+        atg = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                   sectors_degree=np.array([17]), center=np.array([0.0, 0.0, 0.0]))
 
         # errors of aim_weight
         with self.assertRaises(TypeError):
@@ -513,9 +433,8 @@ class TestMolGrid(TestCase):
         coords = np.array([0.0, 0.0, 0.0])
 
         # initialize MolGrid with atomic grid
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid, 0.5, r_sectors=np.array([]), degs=np.array([17]), center=coords
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coords)
         grid = MolGrid([atg1], BeckeWeights(), np.array([1]), store=False)
         fn = np.exp(-2 * np.linalg.norm(grid.points, axis=-1))
         assert_allclose(grid.integrate(fn), np.pi)
@@ -581,13 +500,8 @@ class TestMolGrid(TestCase):
         tf = ExpRTransform(1e-5, 2e1)
         rgrid = tf.transform_1d_grid(pts)
         coordinates = np.array([0.0, 0.0, -0.5])
-        atg1 = AtomGrid.from_pruned(
-            rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates,
-        )
+        atg1 = AtomGrid.from_pruned(rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates)
         mg = MolGrid([atg1], HirshfeldWeights(), np.array([7]))
         dist0 = np.sqrt(((coordinates - mg.points) ** 2).sum(axis=1))
         fn = np.exp(-2 * dist0) / np.pi
@@ -597,20 +511,10 @@ class TestMolGrid(TestCase):
     def test_integrate_hirshfeld_weights_pair_1s(self):
         """Test molecular integral in H2."""
         coordinates = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]])
-        atg1 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[0],
-        )
-        atg2 = AtomGrid.from_pruned(
-            self.rgrid,
-            0.5,
-            r_sectors=np.array([]),
-            degs=np.array([17]),
-            center=coordinates[1],
-        )
+        atg1 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[0])
+        atg2 = AtomGrid.from_pruned(self.rgrid, 0.5, sectors_r=np.array([]),
+                                    sectors_degree=np.array([17]), center=coordinates[1])
         mg = MolGrid([atg1, atg2], HirshfeldWeights(), np.array([1, 1]))
         dist0 = np.sqrt(((coordinates[0] - mg.points) ** 2).sum(axis=1))
         dist1 = np.sqrt(((coordinates[1] - mg.points) ** 2).sum(axis=1))

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -26,7 +26,7 @@ class TestPoisson(TestCase):
         btf = BeckeTF(0.0001, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
-        atgrid = AtomGrid(rad, degs=[l_max])
+        atgrid = AtomGrid(rad, degrees=[l_max])
         value_array = self.helper_func_gauss(atgrid.points)
         spl_res = spline_with_atomic_grid(atgrid, value_array)
         # test for random, r, theta, phi
@@ -68,7 +68,7 @@ class TestPoisson(TestCase):
         btf = BeckeTF(1e-7, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
-        atgrid = AtomGrid(rad, degs=[l_max])
+        atgrid = AtomGrid(rad, degrees=[l_max])
         value_array = self.helper_func_gauss(atgrid.points)
         p_0 = atgrid.integrate(value_array)
 
@@ -146,7 +146,7 @@ class TestPoisson(TestCase):
         btf = BeckeTF(1e-7, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
-        atgrid = AtomGrid(rad, degs=[l_max])
+        atgrid = AtomGrid(rad, degrees=[l_max])
         value_array = self.helper_func_gauss(atgrid.points)
         p_0 = atgrid.integrate(value_array)
 
@@ -204,7 +204,7 @@ class TestPoisson(TestCase):
         btf = BeckeTF(1e-7, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
-        atgrid = AtomGrid(rad, degs=[l_max])
+        atgrid = AtomGrid(rad, degrees=[l_max])
         value_array = self.helper_func_gauss(atgrid.points)
         p_0 = atgrid.integrate(value_array)
 


### PR DESCRIPTION
The current changes update the docstrings of `AtomGrid` to make them complete and consistent. In addition, a few argument names are changes to add clarity. Before making any further changes, I wanted to clarify a few things regarding the `AtomGrid` constructors which are exemplifiedd below:

```python
from grid.atomgrid import AtomGrid
from grid.onedgrid import GaussChebyshev
from grid.rtransform import BeckeTF

oned = GaussChebyshev(30)
rgrid = BeckeTF(1.e-4, 1.5).transform_1d_grid(oned)

# option 1 (using degrees of Levedev grid)
g = AtomGrid(rgrid, degrees=[11])

# option 2 (using atomic number & preset)
g = AtomGrid.from_predefined(rgrid, 1, 'coarse')

# option 2 (using atomic radius & sectors)
g = AtomGrid.from_pruned(rgrid, 0.5, sectors_r=[0.5, 1., 1.5], sectors_degree=[3, 7, 5, 3])
```

1. Considering the fact that the `AtomGrid.from_predefined` loaded precomputed `sectors_r` & `sectors_size`, shouldn't it just call `AtomGrid.from_pruned` upon loading the sectors information? This is not how `AtomGrid.from_predefined` is currently implemented. So, I am a bit confused.
2. In `HORTON2`, the `coarse` built-in grid specifies the radial grid points as well. See: http://theochem.github.io/horton/2.1.1/tech_ref_grids.html?highlight=insane This is not the case for `AtomGrid`, so how are we going to support `HORTOn2`-type built-in grids?

Any comments are welcomed @tczorro, @tovrstra, and @PaulWAyers.