### PR TITLE
Add a condition to fix nan in noble gas atoms #100

### DIFF
--- a/src/grid/becke.py
+++ b/src/grid/becke.py
@@ -158,7 +158,14 @@ class BeckeWeights:
             # mu_p_n_n shape (#points, #uncs, #uncs)
             mu_p_n_n = n_n_p.transpose([2, 0, 1]) / atomic_dist
         del n_n_p
-        radii = np.array([self._radii[num] for num in atnums])
+        radii = np.array(
+            [
+                self._radii[num]
+                if not np.isnan(self._radii[num])
+                else self._radii[num - 1]
+                for num in atnums
+            ]
+        )
         alpha = BeckeWeights._calculate_alpha(radii)
         v_pp = mu_p_n_n + alpha * (1 - mu_p_n_n ** 2)
         del mu_p_n_n
@@ -215,7 +222,14 @@ class BeckeWeights:
             # mu_p_n_n shape (N, M, M)
             mu_p_n_n = n_n_p.transpose([2, 0, 1]) / atomic_dist
         del n_n_p
-        radii = np.array([self._radii[num] for num in atnums])
+        radii = np.array(
+            [
+                self._radii[num]
+                if not np.isnan(self._radii[num])
+                else self._radii[num - 1]
+                for num in atnums
+            ]
+        )
         alpha = BeckeWeights._calculate_alpha(radii)
         v_pp = mu_p_n_n + alpha * (1 - mu_p_n_n ** 2)
         del mu_p_n_n

--- a/src/grid/tests/test_becke.py
+++ b/src/grid/tests/test_becke.py
@@ -129,6 +129,20 @@ class TestBecke(TestCase):
         weights_compute2 = becke.compute_weights(points, centers, nums, select=1)
         assert_allclose(weights_ref2, weights_compute2)
 
+    def test_noble_gas_radius(self):
+        """Test np.nan value to be handled properly."""
+        for i in [2, 10, 18, 36, 54, 85]:
+            nums = np.array([i, i - 1])
+            centers = np.array([[0.5, 0.0, 0.0], [-0.5, 0.0, 0.0]])
+            pts = np.zeros((10, 3), dtype=float)
+            pts[:, 1:] += np.random.rand(10, 2)
+
+            becke = BeckeWeights(order=3)
+            wts = becke.generate_weights(pts, centers, nums, pt_ind=[0, 5, 10])
+            assert_allclose(wts, 0.5)
+            wts = becke.compute_weights(pts, centers, nums, pt_ind=[0, 5, 10])
+            assert_allclose(wts, 0.5)
+
     def test_raise_errors(self):
         """Test errors raise."""
         npoint = 100


### PR DESCRIPTION
1. For most atoms, if nan given, automatically select
atomic radius with 1 less.
`warning`: No.86 RN will still be broken.