### PR TITLE
Add kwargs to preset for a more user friendly API

### DIFF
--- a/src/grid/atomgrid.py
+++ b/src/grid/atomgrid.py
@@ -100,21 +100,21 @@ class AtomGrid(Grid):
         self._size = self._weights.size
 
     @classmethod
-    def from_preset(cls, rgrid, atnum, preset, *_, center=None, rotate=False):
-        """High level to construct prefined atomic grid.
+    def from_preset(cls, rgrid=None, *, atnum, preset, center=None, rotate=False):
+        """High level api to construct an atomic grid with preset arguments.
 
         Examples
         --------
         # construct an atomic grid for H with fine grid setting
-        >>> atgrid = AtomGrid.from_preset(rgrid, 1, "fine")
+        >>> atgrid = AtomGrid.from_preset(rgrid, atnum=1, preset="fine")
 
         Parameters
         ----------
-        rgrid : OneDGrid
+        rgrid : OneDGrid, optional
             The (1-dimensional) radial grid representing the radius of spherical grids.
-        atnum : int
+        atnum : int, keyword-only argument
             The atomic number specifying the predefined grid.
-        preset : str
+        preset : str, keyword-only argument
             The name of predefined grid specifying the radial sectors and their corresponding
             number of Lebedev grid points. Supported preset options include:
             'coarse', 'medium', 'fine', 'veryfine', 'ultrafine', and 'insane'.
@@ -124,6 +124,9 @@ class AtomGrid(Grid):
             Whether to rotate the Lebedev spherical grids at each radial grid point.
             If given an integer, it is used as a seed for generating random rotation matrices.
         """
+        if rgrid is None:
+            # TODO: generate a default rgrid, currently raise an error instead
+            raise ValueError("A default OneDGrid will be generated")
         center = (
             np.zeros(3, dtype=float)
             if center is None

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -151,12 +151,12 @@ class MolGrid(Grid):
         return cls(atnums, atomic_grids, aim_weights, store=store)
 
     @classmethod
-    def horton_molgrid(
+    def from_size(
         cls,
         atnums,
         atcoords,
         rgrid,
-        sizes,
+        size,
         aim_weights,
         rotate=37,
         store=False,
@@ -168,7 +168,7 @@ class MolGrid(Grid):
         >>> onedg = HortonLinear(100) # number of points, oned grid before TF.
         >>> rgrid = ExpRTransform(1e-5, 2e1).generate_radial(onedg) # radial grid
         >>> becke = BeckeWeights(order=3)
-        >>> molgrid = MolGrid.horton_molgrid(atnums, atcoords, rgrid, 110, becke)
+        >>> molgrid = MolGrid.from_size(atnums, atcoords, rgrid, 110, becke)
 
         Parameters
         ----------
@@ -178,7 +178,7 @@ class MolGrid(Grid):
             Cartesian coordinates for each atoms
         rgrid : OneDGrid
             one dimension grid  to construct spherical grid
-        sizes : int
+        size : int
             Num of points on each shell of angular grid
         aim_weights : Callable or np.ndarray(K,)
             Atoms in molecule weights.
@@ -196,7 +196,7 @@ class MolGrid(Grid):
         at_grids = []
         for i in range(len(atcoords)):
             at_grids.append(
-                AtomGrid(rgrid, sizes=[sizes], center=atcoords[i], rotate=rotate)
+                AtomGrid(rgrid, sizes=[size], center=atcoords[i], rotate=rotate)
             )
         return cls(atnums, at_grids, aim_weights, store=store)
 

--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -145,7 +145,7 @@ class MolGrid(Grid):
                     f"Not supported preset type; got preset {preset} with type {type(preset)}"
                 )
             at_grid = AtomGrid.from_preset(
-                rad, atnums[i], gd_type, center=atcoords[i], rotate=rotate
+                rad, atnum=atnums[i], preset=gd_type, center=atcoords[i], rotate=rotate
             )
             atomic_grids.append(at_grid)
         return cls(atnums, atomic_grids, aim_weights, store=store)

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -81,7 +81,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(20)
         tf = PowerRTransform(7.0879993828935345e-06, 16.05937640019924)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_preset(rad_grid, 1, "coarse")
+        atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="coarse")
         # 604 points for coarse H atom
         assert_equal(atgrid.size, 604)
         assert_almost_equal(
@@ -93,7 +93,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(24)
         tf = PowerRTransform(3.69705074304963e-06, 19.279558946793685)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_preset(rad_grid, 1, "medium")
+        atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="medium")
         # 928 points for coarse H atom
         assert_equal(atgrid.size, 928)
         assert_almost_equal(
@@ -104,7 +104,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(34)
         tf = PowerRTransform(2.577533167224667e-07, 16.276983371222354)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_preset(rad_grid, 1, "fine")
+        atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="fine")
         # 1984 points for coarse H atom
         assert_equal(atgrid.size, 1984)
         assert_almost_equal(
@@ -115,7 +115,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(41)
         tf = PowerRTransform(1.1774580743206259e-07, 20.140888089596444)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_preset(rad_grid, 1, "veryfine")
+        atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="veryfine")
         # 3154 points for coarse H atom
         assert_equal(atgrid.size, 3154)
         assert_almost_equal(
@@ -126,7 +126,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(49)
         tf = PowerRTransform(4.883104847991021e-08, 21.05456999309752)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_preset(rad_grid, 1, "ultrafine")
+        atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="ultrafine")
         # 4546 points for coarse H atom
         assert_equal(atgrid.size, 4546)
         assert_almost_equal(
@@ -137,7 +137,7 @@ class TestAtomGrid(TestCase):
         pts = HortonLinear(59)
         tf = PowerRTransform(1.9221827244049134e-08, 21.413278983919113)
         rad_grid = tf.transform_1d_grid(pts)
-        atgrid = AtomGrid.from_preset(rad_grid, 1, "insane")
+        atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="insane")
         # 6622 points for coarse H atom
         assert_equal(atgrid.size, 6622)
         assert_almost_equal(
@@ -381,6 +381,10 @@ class TestAtomGrid(TestCase):
                 sectors_degree=np.array([3, 5, 7, 5]),
                 center=np.array([0, 0, 0, 0]),
             )
+
+        # test preset
+        with self.assertRaises(ValueError):
+            AtomGrid.from_preset(atnum=1, preset="fine")
 
         with self.assertRaises(TypeError):
             AtomGrid(OneDGrid(np.arange(3), np.arange(3)), sizes=110)

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -117,12 +117,14 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_preset(rad2, numbers[0], "fine", center=coordinates[0])
+        atgrid1 = AtomGrid.from_preset(
+            rad2, atnum=numbers[0], preset="fine", center=coordinates[0]
+        )
         atgrid2 = AtomGrid.from_preset(
-            rad2, numbers[1], "veryfine", center=coordinates[1]
+            rad2, atnum=numbers[1], preset="veryfine", center=coordinates[1]
         )
         atgrid3 = AtomGrid.from_preset(
-            rad2, numbers[2], "medium", center=coordinates[2]
+            rad2, atnum=numbers[2], preset="medium", center=coordinates[2]
         )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
@@ -145,11 +147,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_preset(rad3, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_preset(
-            rad3, numbers[1], "veryfine", center=coordinates[1]
+        atgrid1 = AtomGrid.from_preset(
+            rad3, atnum=numbers[0], preset="fine", center=coordinates[0]
         )
-        atgrid3 = AtomGrid.from_preset(rad3, numbers[2], "fine", center=coordinates[2])
+        atgrid2 = AtomGrid.from_preset(
+            rad3, atnum=numbers[1], preset="veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_preset(
+            rad3, atnum=numbers[2], preset="fine", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -183,11 +189,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_preset(rad1, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_preset(
-            rad2, numbers[1], "veryfine", center=coordinates[1]
+        atgrid1 = AtomGrid.from_preset(
+            rad1, atnum=numbers[0], preset="fine", center=coordinates[0]
         )
-        atgrid3 = AtomGrid.from_preset(rad3, numbers[2], "fine", center=coordinates[2])
+        atgrid2 = AtomGrid.from_preset(
+            rad2, atnum=numbers[1], preset="veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_preset(
+            rad3, atnum=numbers[2], preset="fine", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)
@@ -209,11 +219,15 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 3, decimal=3)
 
-        atgrid1 = AtomGrid.from_preset(rad1, numbers[0], "fine", center=coordinates[0])
-        atgrid2 = AtomGrid.from_preset(
-            rad3, numbers[1], "veryfine", center=coordinates[1]
+        atgrid1 = AtomGrid.from_preset(
+            rad1, atnum=numbers[0], preset="fine", center=coordinates[0]
         )
-        atgrid3 = AtomGrid.from_preset(rad1, numbers[2], "fine", center=coordinates[2])
+        atgrid2 = AtomGrid.from_preset(
+            rad3, atnum=numbers[1], preset="veryfine", center=coordinates[1]
+        )
+        atgrid3 = AtomGrid.from_preset(
+            rad1, atnum=numbers[2], preset="fine", center=coordinates[2]
+        )
         assert_allclose(mg._atgrids[0].points, atgrid1.points)
         assert_allclose(mg._atgrids[1].points, atgrid2.points)
         assert_allclose(mg._atgrids[2].points, atgrid3.points)

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -449,14 +449,12 @@ class TestMolGrid(TestCase):
         occupation = mg.integrate(fn)
         assert_almost_equal(occupation, 4.0, decimal=4)
 
-    def test_horton_molgrid(self):
+    def test_from_size(self):
         """Test horton style grid."""
         nums = np.array([1, 1])
         coors = np.array([[0, 0, -0.5], [0, 0, 0.5]])
         becke = BeckeWeights(order=3)
-        mol_grid = MolGrid.horton_molgrid(
-            nums, coors, self.rgrid, 110, becke, rotate=False
-        )
+        mol_grid = MolGrid.from_size(nums, coors, self.rgrid, 110, becke, rotate=False)
         atg1 = AtomGrid.from_pruned(
             self.rgrid,
             0.5,
@@ -575,7 +573,7 @@ class TestMolGrid(TestCase):
         assert_allclose(wholegrid.indices, np.arange(grid.size))
 
         # initialize MolGrid like horton
-        grid = MolGrid.horton_molgrid(
+        grid = MolGrid.from_size(
             nums, coords[np.newaxis, :], self.rgrid, 110, BeckeWeights(), store=True
         )
         fn = np.exp(-4.0 * np.linalg.norm(grid.points, axis=-1))
@@ -591,7 +589,7 @@ class TestMolGrid(TestCase):
         """Test local grid for a molecule with one atom."""
         nums = np.array([1, 3])
         coords = np.array([[0.0, 0.0, -0.5], [0.0, 0.0, 0.5]])
-        grid = MolGrid.horton_molgrid(
+        grid = MolGrid.from_size(
             nums, coords, self.rgrid, 110, BeckeWeights(), store=True, rotate=False
         )
         fn0 = np.exp(-4.0 * np.linalg.norm(grid.points - coords[0], axis=-1))


### PR DESCRIPTION
Changs in `AtomGrid`
1. Set `rgrid` optional
2. Set `atnum` and `preset` to kwargs only