### PR TITLE
Refactor documentation in onedgrid and rtransform

### DIFF
--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -165,7 +165,7 @@ class MolGrid(Grid):
 
         Example
         -------
-        >>> onedg = HortonLinear(100) # number of points, oned grid before TF.
+        >>> onedg = UniformInteger(100) # number of points, oned grid before TF.
         >>> rgrid = ExpRTransform(1e-5, 2e1).generate_radial(onedg) # radial grid
         >>> becke = BeckeWeights(order=3)
         >>> molgrid = MolGrid.from_size(atnums, atcoords, rgrid, 110, becke)

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -20,7 +20,7 @@
 """Generic ode solver module."""
 # from numbers import Number
 
-# from grid.rtransform import InverseTF
+# from grid.rtransform import InverseRTransform
 from numbers import Number
 
 import numpy as np

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -28,21 +28,26 @@ from scipy.special import roots_chebyu, roots_genlaguerre
 
 
 class GaussLaguerre(OneDGrid):
-    """Gauss Laguerre integral quadrature class."""
+    r"""
+    Gauss Laguerre integral quadrature class.
 
-    def __init__(self, npoints: int, alpha: float = 0):
-        r"""Generate 1-D grid on [0, inf) interval based on Generalized Gauss-Laguerre quadrature.
+    The definition of generalized Gauss-Laguerre quadrature is:
 
-        The fundamental definition of Generalized Gauss-Laguerre quadrature is:
+    .. math::
+        \int_{0}^{\infty} x^\alpha e^{-x} f(x) dx \approx \sum_{i=1}^n w_i f(x_i),
 
-        .. math::
-        \int_{0}^{\infty} x^\alpha e^{-x} f(x) dx \approx \sum_{i=1}^n w_i f(x_i)
+    where :math:`\alpha > -1`.
 
-        However, to integrate function :math:`g(x)` over [0, inf), this is re-written as:
+    However, to integrate function :math:`g(x)` over :math:`[0, \infty)`, this is re-written as:
 
-        .. math::
+    .. math::
         \int_{0}^{\infty} g(x)dx \approx
         \sum_{i=1}^n \left(\frac{w_i}{x_i^\alpha e^{-x_i}}\right) g(x_i) = \sum_{i=1}^n w_i' g(x_i)
+
+    """
+
+    def __init__(self, npoints: int, alpha: float = 0):
+        r"""Generate grid on :math:`[0, \infty)` based on generalized Gauss-Laguerre quadrature.
 
         Parameters
         ----------
@@ -70,18 +75,21 @@ class GaussLaguerre(OneDGrid):
 
 
 class GaussLegendre(OneDGrid):
-    """Gauss-Legendre integral quadrature class."""
+    r"""
+    Gauss-Legendre integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Legendre quadrature.
+    The definition of Gauss-Legendre quadrature is:
 
-        The fundamental definition of Gauss-Legendre quadrature is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} f(x) dx \approx \sum_{i=1}^n w_i f(x_i),
 
-        where :math:`w_i` are the quadrature weights and :math:`x_i` are the
-        roots of the nth Legendre polynomial.
+    where :math:`w_i` are the quadrature weights and :math:`x_i` are the
+    roots of the nth Legendre polynomial.
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1, 1]` interval based on Gauss-Legendre quadrature.
 
         Parameters
         ----------
@@ -110,23 +118,26 @@ class GaussLegendre(OneDGrid):
 
 
 class GaussChebyshev(OneDGrid):
-    """Gauss Chesbyshev integral quadrature class."""
+    r"""
+    Gauss-Chebyshev integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Chebyshev quadrature.
+    The fundamental definition of Gauss-Chebyshev quadrature is:
 
-        The fundamental definition of Gauss-Chebyshev quadrature is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} \frac{f(x)}{\sqrt{1-x^2}} dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& \cos\left( \frac{2i-1}{2n}\pi \right) \\
         w_i =& \frac{\pi}{n}
 
-        However, to integrate a given function :math:`g(x)` over [-1, 1], this is re-written as:
+    However, to integrate a given function :math:`g(x)` over :math:`[-1, 1]`, this is re-written as:
 
-        .. math::
+    .. math::
         \int_{-1}^{1}g(x)dx \approx \sum_{i=1}^n \left(w_i\sqrt{1-x_i^2}\right)g(x_i) =
         \sum_{i=1}^n w_i'g(x_i)
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1, 1]` interval based on Gauss-Chebyshev quadrature.
 
         Parameters
         ----------
@@ -152,15 +163,17 @@ class GaussChebyshev(OneDGrid):
 
 
 class UniformInteger(OneDGrid):
-    """HORTON2 integral quadrature (HortonLinear) class."""
+    r"""
+    HORTON2 integral quadrature (HortonLinear) class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [0, npoints] interval using equally spaced uniform distribution.
-
-        .. math::
+    .. math::
         \int_{0}^{n} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& i - 1 \\
         w_i =& 1.0
+
+    """
+    def __init__(self, npoints: int):
+        r"""Generate grid on [0, npoints] interval using equally spaced uniform distribution.
 
         Parameters
         ----------
@@ -170,7 +183,7 @@ class UniformInteger(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1-D grid instance containing points and weights.
+            One-dimensional grid instance containing points and weights.
 
         """
         if npoints <= 1:
@@ -183,23 +196,26 @@ class UniformInteger(OneDGrid):
 
 
 class GaussChebyshevType2(OneDGrid):
-    """Gauss Chebyshev Type2 integral quadrature class."""
+    r"""
+    Gauss Chebyshev Type2 integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Chebyshev Type 2.
+    The definition of the Gauss-Chebyshev of the second kind quadrature is:
 
-        The fundamental definition of Gauss-Chebyshev Type 2 quadrature is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} f(x) \sqrt{1-x^2} dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& \cos\left( \frac{i}{n+1} \pi \right) \\
         w_i =& \frac{\pi}{n+1} \sin^2 \left( \frac{i}{n+1} \pi \right)
 
-        However, to integrate a given function :math:`g(x)` over [-1, 1], this is re-written as:
+    However, to integrate a given function :math:`g(x)` over :math:`[-1, 1]`, this is re-written as:
 
-        .. math::
+    .. math::
         \int_{-1}^{1} g(x) dx \approx \sum_{i=1}^n \left(\frac{w_i}{\sqrt{1-x_i^2}}\right) g(x_i) =
         \sum_{i=1}^n w_i' g(x_i)
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1, 1]` interval based on Gauss-Chebyshev Type 2.
 
         Parameters
         ----------
@@ -223,24 +239,26 @@ class GaussChebyshevType2(OneDGrid):
 
 
 class GaussChebyshevLobatto(OneDGrid):
-    """Gauss Chebyshev Lobatto integral quadrature class."""
+    r"""
+    Gauss Chebyshev Lobatto integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Chebyshev-Lobatto quadrature.
+    The definition of Gauss-Chebyshev-Lobato quadrature is:
 
-        The definition of Gauss-Chebyshev-Lobato quadrature is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} \frac{f(x)}{\sqrt{1-x^2}} dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& \cos\left( \frac{(i-1)}{n-1}\pi \right) \\
         w_{1} = w_{n} =& \frac{\pi}{2(n-1)} \\
         w_{i\neq 1,n} =& \frac{\pi}{n-1}
 
-        However, to integrate a given function :math:`g(x)` over [-1, 1], this is re-written as:
+    However, to integrate a given function :math:`g(x)` over :math:`[-1, 1]`, this is re-written as:
 
-        .. math::
+    .. math::
         \int_{-1}^{1}g(x) dx \approx \sum_{i=1}^n \left(w_i \sqrt{1-x_i^2}\right) g(x_i) =
         \sum_{i=1}^n w_i' g(x_i)
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1, 1]` interval based on Gauss-Chebyshev-Lobatto quadrature.
 
         Parameters
         ----------
@@ -269,18 +287,21 @@ class GaussChebyshevLobatto(OneDGrid):
 
 
 class Trapezoidal(OneDGrid):
-    """Trapezoidal Lobatto integral quadrature class."""
+    r"""
+    Trapezoidal Lobatto integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval based on Trapezoidal (Euler-Maclaurin) rule.
+    The fundamental definition of Trapezoidal rule is:
 
-        The fundamental definition of Trapezoidal rule is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& -1 + 2 \left(\frac{i-1}{n-1}\right) \\
         w_1 = w_n =& \frac{1}{n} \\
         w_{i\neq 1,n} =& \frac{2}{n}
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on [-1, 1] interval based on Trapezoidal (Euler-Maclaurin) rule.
 
         Parameters
         ----------
@@ -290,7 +311,7 @@ class Trapezoidal(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1-D grid instance containing points and weights.
+            One-dimensional grid instance containing points and weights.
 
         """
         if npoints <= 1:
@@ -308,7 +329,18 @@ class Trapezoidal(OneDGrid):
 
 class RectangleRuleSineEndPoints(OneDGrid):
     """
-    Rectangle-Rule Sine EndPoints integral quadrature class.
+    Rectangle-Rule Sine end points integral quadrature class.
+
+     .. math::
+        \int_{-1}^{1} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
+        x_i =& \frac{i}{n+1} \\
+        w_i =& \frac{2}{n+1} \sum_{m=1}^n \frac{\sin(m \pi x_i)(1-\cos(m \pi))}{m \pi}
+
+    For consistency with other 1-D grids, the integration range is modified
+    by :math:`q=2x-1` to the interval :math:`[-1, 1]`, so that
+
+    .. math::
+        2 \int_{0}^{1} f(x) dx = \int_{-1}^{1} f(q) dq
 
     References
     ----------
@@ -317,18 +349,7 @@ class RectangleRuleSineEndPoints(OneDGrid):
 
     def __init__(self, npoints: int):
         r"""
-        Generate 1-D grid on [-1, 1] using rectangle rule for Sine Series (with endpoints).
-
-        .. math::
-        \int_{-1}^{1} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
-        x_i =& \frac{i}{n+1} \\
-        w_i =& \frac{2}{n+1} \sum_{m=1}^n \frac{\sin(m \pi x_i)(1-\cos(m \pi))}{m \pi}
-
-        For consistency with other 1-D grids, the integration range is modified
-        by :math:`q=2x-1`, and
-
-        .. math::
-        2 \int_{0}^{1} f(x) dx = \int_{-1}^{1} f(q) dq
+        Generate grid on :math:`[-1, 1]` using rectangle rule for Sine Series (with endpoints).
 
         Parameters
         ----------
@@ -338,7 +359,7 @@ class RectangleRuleSineEndPoints(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1-D grid instance containing points and weights.
+            One-dimensional grid instance containing points and weights.
 
         """
         if npoints <= 1:
@@ -365,28 +386,29 @@ class RectangleRuleSineEndPoints(OneDGrid):
 
 
 class RectangleRuleSine(OneDGrid):
-    """
+    r"""
     Rectangle-Rule Sine integral quadrature class.
 
-    References
-    ----------
-    .. [1] Boyd, John P. Chebyshev and Fourier spectral methods. Courier Corporation, 2001.
-    """
-
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval using Interior Rectangle Rule for Sines.
-
-        .. math::
+    .. math::
         \int_{-1}^{1} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& \frac{2 i - 1}{2 n} \\
         w_i =& \frac{2}{n^2 \pi} \sin(n\pi x_i) \sin^2(n\pi /2) +
                 \frac{4}{n \pi} \sum_{m=1}^{n-1} \frac{\sin(m \pi x_i)\sin^2(m\pi /2)}{m}
 
-        For consistency with other 1-D grids, the integration range is modified
-        by :math:`q=2x-1`, and
+    For consistency with other 1-D grids, the integration range is modified
+    by :math:`q=2x-1` to the interval :math:`[-1, 1]`, such that
 
-        .. math::
+    .. math::
         2 \int_{0}^{1} f(x) dx = \int_{-1}^{1} f(q) dq
+
+    References
+    ----------
+    .. [1] Boyd, John P. Chebyshev and Fourier spectral methods. Courier Corporation, 2001.
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1, 1]` interval using Interior Rectangle Rule for Sines.
 
         Parameters
         ----------
@@ -396,7 +418,7 @@ class RectangleRuleSine(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1-D grid instance containing points and weights.
+            One-dimensional grid instance containing points and weights.
 
         """
         if npoints <= 1:
@@ -426,20 +448,23 @@ class RectangleRuleSine(OneDGrid):
 
 
 class TanhSinh(OneDGrid):
-    """Tanh Sinh integral quadrature class."""
+    r"""
+    Tanh Sinh integral quadrature class.
 
-    def __init__(self, npoints: int, delta: float = 0.1):
-        r"""Generate 1-D grid on :math:`[-1, 1]` interval based on Tanh-Sinh rule.
+    The definition of the quadrature is:
 
-        The fundamental definition is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} f(x) dx \approx& \sum_{i=-\frac{1}{2}(n-1)}^{\frac{1}{2}(n-1)} w_i f(x_i) \\
         x_i =& \tanh\left( \frac{\pi}{2} \sinh(i\delta) \right) \\
         w_i =& \frac{\frac{\pi}{2}\delta \cosh(i\delta)}{\cosh^2(\frac{\pi}{2}\sinh(i\delta))}
 
-        This quadrature is useful when singularities or infinite derivatives exist on the
-        endpoints of :math:`[-1, 1]`.
+    This quadrature is useful when singularities or infinite derivatives exist on the
+    endpoints of :math:`[-1, 1]`.
+
+    """
+
+    def __init__(self, npoints: int, delta: float = 0.1):
+        r"""Generate grid on :math:`[-1, 1]` interval based on Tanh-Sinh rule.
 
         Parameters
         ----------
@@ -475,26 +500,27 @@ class TanhSinh(OneDGrid):
 
 
 class Simpson(OneDGrid):
-    """Simpson integral quadrature class."""
+    r"""Simpson integral quadrature class.
+
+    The definition of this quadrature is:
+
+    .. math::
+        \int_{-1}^{1} f(x) dx \approx \sum_{i=1}^n w_i f(x_i),
+
+    where
+
+    .. math::
+        x_i &= -1 + 2 \left(\frac{i-1}{n-1}\right),
+        w_i &= \begin{cases}
+            2 / (3(N - 1)) & i = 0 \\
+            8 / (3(N - 1)) & i \geq 1 \text{and is odd}, \\
+            4 / (3(N - 1)) & i \geq 2 \text{and is even}.
+        \end{cases}
+
+    """
 
     def __init__(self, npoints: int):
-        r"""Generate 1D grid on [-1,1] interval based on Simpson rule.
-
-        The fundamental definition of this rule is:
-
-        .. math::
-            \int_{-1}^{1} f(x) dx \approx \sum_{i=1}^n w_i f(x_i),
-
-        where
-
-        .. math::
-            x_i &= -1 + 2 \left(\frac{i-1}{n-1}\right),
-            w_i &= \begin{cases}
-                2 / (3(N - 1)) & i = 0 \\
-                8 / (3(N - 1)) & i \geq 1 \text{and is odd}, \\
-                4 / (3(N - 1)) & i \geq 2 \text{and is even}.
-            \end{cases}
-
+        r"""Generate grid on :math:`[-1,1]` interval based on Simpson rule.
 
         Parameters
         ----------
@@ -523,17 +549,19 @@ class Simpson(OneDGrid):
 
 
 class MidPoint(OneDGrid):
-    """MidPoint integral quadrature class."""
+    r"""MidPoint integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval based on Mid-Point rule.
+    The definition of this quadrature is:
 
-        The fundamental definition is:
-
-        .. math::
+    .. math::
         \int_{-1}^{1} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
         x_i =& -1 + \frac{2i + 1}{n} \\
         w_i =& \frac{2}{n}
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1, 1]` interval based on Mid-Point rule.
 
         Parameters
         ----------
@@ -543,7 +571,7 @@ class MidPoint(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1-D grid instance containing points and weights.
+            One-dimensional grid instance containing points and weights.
 
         """
         if npoints <= 1:
@@ -558,14 +586,11 @@ class MidPoint(OneDGrid):
 
 
 class ClenshawCurtis(OneDGrid):
-    """Clenshow Curtis integral quadrature class."""
+    """Clenshow Curtis integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1D grid on [-1,1] interval based on Clenshaw-Curtis method.
+    The definition of this quadrature is:
 
-        The fundamental definition is:
-
-        .. math::
+    .. math::
         \theta_i &= \pi (i - 1) / (n - 1) \\
         x_i &= \cos (\theta_i) \\
         w_i &= \frac{c_k}{n} \bigg(1 - \sum_{j=1}^{\lfloor n/2 \rfloor}
@@ -579,10 +604,15 @@ class ClenshawCurtis(OneDGrid):
             2 & else
         \end{cases}
 
-        where :math:k`=0,\cdots,n.
+    where :math:k`=0,\cdots,n.
 
-        If discontinuous, it is recommended to break the intervals at the discontinuities
-        and handled separately.
+    If discontinuous, it is recommended to break the intervals at the discontinuities
+    and handled separately.
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`[-1,1]` interval based on Clenshaw-Curtis method.
 
         Parameters
         ----------
@@ -620,22 +650,25 @@ class ClenshawCurtis(OneDGrid):
 
 
 class FejerFirst(OneDGrid):
-    """Fejer first integral quadrature class."""
+    r"""
+    Fejer first integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1D grid on (-1,1) interval based on Fejer's first rule.
+    The definition of this quadrature is:
 
-        The fundamental definition is:
-
-        .. math::
+    .. math::
         \theta_i &= \frac{(2i - 1)\pi}{2n},
         x_i &= \cos(\theta_i),
         w_i &= \frac{2}{n}\bigg(1 - 2 \sum_{j=1}^{\lfloor n/2 \rfloor}
             \frac{\cos(2j \theta_j)}{4 j^2 - 1} \bigg),
 
-        where :math:`k=1,\cdots, n`. It uses the zeros of the Chebyshev polynomial.
-        If discontinuous, it is recommended to break the intervals at the discontinuities
-        and handled separately.
+    where :math:`k=1,\cdots, n`. It uses the zeros of the Chebyshev polynomial.
+    If discontinuous, it is recommended to break the intervals at the discontinuities
+    and handled separately.
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate 1D grid on :math:`(-1,1)` interval based on Fejer's first rule.
 
         Parameters
         ----------
@@ -669,22 +702,25 @@ class FejerFirst(OneDGrid):
 
 
 class FejerSecond(OneDGrid):
-    """Fejer Second integral quadrature class."""
+    r"""
+    Fejer Second integral quadrature class.
 
-    def __init__(self, npoints: int):
-        r"""Generate 1D grid on (-1,1) interval based on Fejer's second rule.
+    The definition of this quadrature is:
 
-        The fundamental definition is:
-
-        .. math::
+    .. math::
         theta_i &= k \pi / n \\
         x_i &= \cos(\theta_i) \\
         w_i &= \frac{4 \sin(\theta_i)}{n} \sum_{j=1}^{\lfloor n/2 \rfloor}
             \frac{\sin(2j - 1)\theta_i}{2j - 1}\\
 
-        where :math:`k=1, \cdots n - 1` and :math:`n` is the number of points. This
-        method is considered more practical than the first method.  If discontinuous, it is
-        recommended to break the intervals at the discontinuities and handled separately.
+    where :math:`k=1, \cdots n - 1` and :math:`n` is the number of points. This
+    method is considered more practical than the first method.  If discontinuous, it is
+    recommended to break the intervals at the discontinuities and handled separately.
+
+    """
+
+    def __init__(self, npoints: int):
+        r"""Generate grid on :math:`(-1,1)` interval based on Fejer's second rule.
 
         Parameters
         ----------
@@ -935,7 +971,7 @@ class TrefethenStripCC(OneDGrid):
     """
 
     def __init__(self, npoints: int, rho=1.1):
-        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Clenshaw-Curtis.
+        r"""Generate grid on :math:`[-1,1]` interval based on Trefethen-Clenshaw-Curtis.
 
         Parameters
         ----------
@@ -964,7 +1000,7 @@ class TrefethenStripGC2(OneDGrid):
     """
 
     def __init__(self, npoints: int, rho=1.1):
-        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Gauss-Chebyshev.
+        r"""Generate grid on :math:`[-1,1]` interval based on Trefethen-Gauss-Chebyshev.
 
         Parameters
         ----------
@@ -994,7 +1030,7 @@ class TrefethenStripGeneral(OneDGrid):
     """
 
     def __init__(self, npoints: int, quadrature, rho=1.1):
-        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-General.
+        r"""Generate grid on :math:`[-1,1]` interval based on Trefethen-General.
 
         Parameters
         ----------

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -307,7 +307,13 @@ class Trapezoidal(OneDGrid):
 
 
 class RectangleRuleSineEndPoints(OneDGrid):
-    """Rectangle-Rule Sine EndPoints integral quadrature class."""
+    """
+    Rectangle-Rule Sine EndPoints integral quadrature class.
+
+    References
+    ----------
+    .. [1] Boyd, John P. Chebyshev and Fourier spectral methods. Courier Corporation, 2001.
+    """
 
     def __init__(self, npoints: int):
         r"""
@@ -359,7 +365,13 @@ class RectangleRuleSineEndPoints(OneDGrid):
 
 
 class RectangleRuleSine(OneDGrid):
-    """Rectangle-Rule Sine integral quadrature class."""
+    """
+    Rectangle-Rule Sine integral quadrature class.
+
+    References
+    ----------
+    .. [1] Boyd, John P. Chebyshev and Fourier spectral methods. Courier Corporation, 2001.
+    """
 
     def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval using Interior Rectangle Rule for Sines.

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -151,8 +151,8 @@ class GaussChebyshev(OneDGrid):
         super().__init__(points[::-1], weights, (-1, 1))
 
 
-class HortonLinear(OneDGrid):
-    """HORTON2 integral quadrature class."""
+class UniformInteger(OneDGrid):
+    """HORTON2 integral quadrature (HortonLinear) class."""
 
     def __init__(self, npoints: int):
         r"""Generate 1-D grid on [0, npoints] interval using equally spaced uniform distribution.

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -30,7 +30,7 @@ from scipy.special import roots_chebyu, roots_genlaguerre
 class GaussLaguerre(OneDGrid):
     """Gauss Laguerre integral quadrature class."""
 
-    def __init__(self, npoints, alpha=0):
+    def __init__(self, npoints: int, alpha: float = 0):
         r"""Generate 1-D grid on [0, inf) interval based on Generalized Gauss-Laguerre quadrature.
 
         The fundamental definition of Generalized Gauss-Laguerre quadrature is:
@@ -72,13 +72,16 @@ class GaussLaguerre(OneDGrid):
 class GaussLegendre(OneDGrid):
     """Gauss Legendre integral quadrature class."""
 
-    def __init__(self, npoints):
-        r"""Generate 1-D grid on (-1, 1) interval based on Gauss-Legendre quadrature.
+    def __init__(self, npoints: int):
+        r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Legendre quadrature.
 
         The fundamental definition of Gauss-Legendre quadrature is:
 
         .. math::
-        \int_{-1}^{1} f(x) dx \approx \sum_{i=1}^n w_i f(x_i)
+        \int_{-1}^{1} f(x) dx \approx \sum_{i=1}^n w_i f(x_i),
+
+        where :math:`w_i` are the quadrature weights and :math:`x_i` are the
+        roots of the nth Legendre polynomial.
 
         Parameters
         ----------
@@ -103,7 +106,7 @@ class GaussLegendre(OneDGrid):
 class GaussChebyshev(OneDGrid):
     """Gauss Chesbyshev integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Chebyshev quadrature.
 
         The fundamental definition of Gauss-Chebyshev quadrature is:
@@ -145,7 +148,7 @@ class GaussChebyshev(OneDGrid):
 class HortonLinear(OneDGrid):
     """HORTON2 integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [0, npoints] interval using equally spaced uniform distribution.
 
         .. math::
@@ -176,7 +179,7 @@ class HortonLinear(OneDGrid):
 class GaussChebyshevType2(OneDGrid):
     """Gauss Chebyshev Type2 integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Chebyshev Type 2.
 
         The fundamental definition of Gauss-Chebyshev Type 2 quadrature is:
@@ -216,7 +219,7 @@ class GaussChebyshevType2(OneDGrid):
 class GaussChebyshevLobatto(OneDGrid):
     """Gauss Chebyshev Lobatto integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval based on Gauss-Chebyshev-Lobatto quadrature.
 
         The definition of Gauss-Chebyshev-Lobato quadrature is:
@@ -262,7 +265,7 @@ class GaussChebyshevLobatto(OneDGrid):
 class Trapezoidal(OneDGrid):
     """Trapezoidal Lobatto integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval based on Trapezoidal (Euler-Maclaurin) rule.
 
         The fundamental definition of Trapezoidal rule is:
@@ -300,7 +303,7 @@ class Trapezoidal(OneDGrid):
 class RectangleRuleSineEndPoints(OneDGrid):
     """Rectangle-Rule Sine EndPoints integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval using Rectangle Rule for Sine Series (with endpoints).
 
         .. math::
@@ -351,7 +354,7 @@ class RectangleRuleSineEndPoints(OneDGrid):
 class RectangleRuleSine(OneDGrid):
     """Rectangle-Rule Sine integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval using Interior Rectangle Rule for Sines.
 
         .. math::
@@ -406,8 +409,8 @@ class RectangleRuleSine(OneDGrid):
 class TanhSinh(OneDGrid):
     """Tanh Sinh integral quadrature class."""
 
-    def __init__(self, npoints, delta=0.1):
-        r"""Generate 1-D grid on [-1, 1] interval based on Tanh-Sinh rule.
+    def __init__(self, npoints: int, delta: float =0.1):
+        r"""Generate 1-D grid on :math:`[-1, 1]` interval based on Tanh-Sinh rule.
 
         The fundamental definition is:
 
@@ -452,7 +455,7 @@ class TanhSinh(OneDGrid):
 class Simpson(OneDGrid):
     """Simpson integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1D grid on [-1,1] interval based on Simpson rule.
 
         The fundamental definition of this rule is:
@@ -495,7 +498,7 @@ class Simpson(OneDGrid):
 class MidPoint(OneDGrid):
     """MidPoint integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1-D grid on [-1, 1] interval based on Mid-Point rule.
 
         The fundamental definition is:
@@ -530,7 +533,7 @@ class MidPoint(OneDGrid):
 class ClenshawCurtis(OneDGrid):
     """Clenshow Curtis integral quadrature class."""
 
-    def __init__(self, npoints):
+    def __init__(self, npoints: int):
         r"""Generate 1D grid on [-1,1] interval based on Clenshaw-Curtis method.
 
         The fundamental definition is:
@@ -549,6 +552,7 @@ class ClenshawCurtis(OneDGrid):
         -------
         OneDGrid
             A 1D grid instance.
+
         """
         if npoints <= 1:
             raise ValueError("npoints must be greater that one, given {npoints}")
@@ -577,8 +581,8 @@ class ClenshawCurtis(OneDGrid):
 class FejerFirst(OneDGrid):
     """Fejer Fisrt integral quadrature class."""
 
-    def __init__(self, npoints):
-        r"""Generate 1D grid on [-1,1] interval based on Fejer-1 method.
+    def __init__(self, npoints: int):
+        r"""Generate 1D grid on (-1,1) interval based on Fejer's first rule.
 
         The fundamental definition is:
 
@@ -596,6 +600,7 @@ class FejerFirst(OneDGrid):
         -------
         OneDGrid
             A 1D grid instance.
+
         """
         if npoints <= 1:
             raise ValueError("npoints must be greater that one, given {npoints}")
@@ -620,8 +625,8 @@ class FejerFirst(OneDGrid):
 class FejerSecond(OneDGrid):
     """Fejer Second integral quadrature class."""
 
-    def __init__(self, npoints):
-        r"""Generate 1D grid on [-1,1] interval based on Fejer-2 method.
+    def __init__(self, npoints: int):
+        r"""Generate 1D grid on (-1,1) interval based on Fejer's second rule.
 
         The fundamental definition is:
 
@@ -693,7 +698,7 @@ def _derg3(x):
 class TrefethenCC(OneDGrid):
     """Trefethen CC integral quadrature class."""
 
-    def __init__(self, npoints, d=3):
+    def __init__(self, npoints: int, d: int =3):
         r"""Generate 1D grid on [-1,1] interval based on Trefethen-Clenshaw-Curtis.
 
         Parameters
@@ -755,7 +760,7 @@ class TrefethenGC2(OneDGrid):
 class TrefethenGeneral(OneDGrid):
     """Trefethen General integral quadrature class."""
 
-    def __init__(self, npoints, quadrature, d=3):
+    def __init__(self, npoints: int, quadrature, d=3):
         r"""Generate 1D grid on [-1,1] interval based on Trefethen-General.
 
         Parameters
@@ -831,8 +836,8 @@ def _dergstrip(rho, s):
 class TrefethenStripCC(OneDGrid):
     """Trefethen Strip CC integral quadrature class."""
 
-    def __init__(self, npoints, rho=1.1):
-        r"""Generate 1D grid on [-1,1] interval based on Trefethen-Clenshaw-Curtis.
+    def __init__(self, npoints: int, rho=1.1):
+        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Clenshaw-Curtis.
 
         Parameters
         ----------
@@ -854,8 +859,8 @@ class TrefethenStripCC(OneDGrid):
 class TrefethenStripGC2(OneDGrid):
     """Trefethen Strip GC2 integral quadrature class."""
 
-    def __init__(self, npoints, rho=1.1):
-        r"""Generate 1D grid on [-1,1] interval based on Trefethen-Gauss-Chebyshev.
+    def __init__(self, npoints: int, rho=1.1):
+        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Gauss-Chebyshev.
 
         Parameters
         ----------
@@ -866,6 +871,7 @@ class TrefethenStripGC2(OneDGrid):
         -------
         OneDGrid
             A 1D grid instance.
+
         """
         grid = GaussChebyshevType2(npoints)
         points = _gstrip(rho, grid.points)
@@ -877,8 +883,8 @@ class TrefethenStripGC2(OneDGrid):
 class TrefethenStripGeneral(OneDGrid):
     """Trefethen Strip General integral quadrature class."""
 
-    def __init__(self, npoints, quadrature, rho=1.1):
-        r"""Generate 1D grid on [-1,1] interval based on Trefethen-General.
+    def __init__(self, npoints: int, quadrature, rho=1.1):
+        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-General.
 
         Parameters
         ----------
@@ -889,6 +895,7 @@ class TrefethenStripGeneral(OneDGrid):
         -------
         OneDGrid
             A 1D grid instance.
+
         """
         grid = quadrature(npoints)
         points = _gstrip(rho, grid.points)

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -438,7 +438,7 @@ class TanhSinh(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1-D grid instance containing points and weights.
+            One-dimensional grid instance containing points and weights.
 
         """
         if npoints <= 1:
@@ -491,7 +491,7 @@ class Simpson(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
 
         """
         if npoints <= 1:
@@ -555,7 +555,7 @@ class ClenshawCurtis(OneDGrid):
         .. math::
         \theta_i &= \pi (i - 1) / (n - 1) \\
         x_i &= \cos (\theta_i) \\
-        w_i &= \frac{c_k}{n} \bigg(1 - \sum_{j=1}^{n/2} \frac{b_j}{4j^2 - 1} \cos(2j\theta_i) \bigg)
+        w_i &= \frac{c_k}{n} \bigg(1 - \sum_{j=1}^{\lfloor n/2 \rfloor} \frac{b_j}{4j^2 - 1} \cos(2j\theta_i) \bigg)
         b_j = \begin{cases}
             1 & \text{if } j = n/2 \\
             2 & \text{if } j < n/2
@@ -578,7 +578,7 @@ class ClenshawCurtis(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
 
         """
         if npoints <= 1:
@@ -616,7 +616,7 @@ class FejerFirst(OneDGrid):
         .. math::
         \theta_i &= \frac{(2i - 1)\pi}{2n},
         x_i &= \cos(\theta_i),
-        w_i &= \frac{2}{n}\bigg(1 - 2 \sum_{j=1}^{n/2} \frac{\cos(2j \theta_j)}{4 j^2 - 1} \bigg),
+        w_i &= \frac{2}{n}\bigg(1 - 2 \sum_{j=1}^{\lfloor n/2 \rfloor} \frac{\cos(2j \theta_j)}{4 j^2 - 1} \bigg),
 
         where :math:`k=1,\cdots, n`. It uses the zeros of the Chebyshev polynomial.
         If discontinuous, it is recommended to break the intervals at the discontinuities
@@ -630,7 +630,7 @@ class FejerFirst(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
 
         """
         if npoints <= 1:
@@ -664,7 +664,7 @@ class FejerSecond(OneDGrid):
         .. math::
         theta_i &= k \pi / n \\
         x_i &= \cos(\theta_i) \\
-        w_i &= \frac{4 \sin(\theta_i)}{n} \sum_{j=1}^{n/2} \frac{\sin(2j - 1)\theta_i}{2j - 1}\\
+        w_i &= \frac{4 \sin(\theta_i)}{n} \sum_{j=1}^{\lfloor n/2 \rfloor} \frac{\sin(2j - 1)\theta_i}{2j - 1}\\
 
         where :math:`k=1, \cdots n - 1` and :math:`n` is the number of points. This
         method is considered more practical than the first method.  If discontinuous, it is
@@ -678,7 +678,7 @@ class FejerSecond(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
         """
         if npoints <= 1:
             raise ValueError("npoints must be greater that one, given {npoints}")

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -395,7 +395,7 @@ class RectangleRuleSine(OneDGrid):
         points = (2 * np.arange(1, npoints + 1, 1) - 1) / (2 * npoints)
 
         weights = (
-            (2 / (npoints * np.pi ** 2))
+            (2 / (npoints * np.pi**2))
             * np.sin(npoints * np.pi * points)
             * np.sin(npoints * np.pi / 2) ** 2
         )
@@ -416,7 +416,7 @@ class RectangleRuleSine(OneDGrid):
 class TanhSinh(OneDGrid):
     """Tanh Sinh integral quadrature class."""
 
-    def __init__(self, npoints: int, delta: float =0.1):
+    def __init__(self, npoints: int, delta: float = 0.1):
         r"""Generate 1-D grid on :math:`[-1, 1]` interval based on Tanh-Sinh rule.
 
         The fundamental definition is:
@@ -645,7 +645,7 @@ class FejerFirst(OneDGrid):
         nsum = npoints // 2
         j = np.arange(nsum - 1) + 1
 
-        bj = 2.0 * np.ones(nsum - 1) / (4 * j ** 2 - 1)
+        bj = 2.0 * np.ones(nsum - 1) / (4 * j**2 - 1)
         cij = np.cos(np.outer(2 * j, theta))
         di = bj @ cij
         weights = 1 - di
@@ -712,25 +712,25 @@ class FejerSecond(OneDGrid):
 # this functions work for TrefethenCC, TrefethenGC2, and TrefethenGeneral
 def _g2(x):
     r"""Return an auxiliary function g2(x) for Trefethen transformation."""
-    return (1 / 149) * (120 * x + 20 * x ** 3 + 9 * x ** 5)
+    return (1 / 149) * (120 * x + 20 * x**3 + 9 * x**5)
 
 
 def _derg2(x):
     r"""Return the derivative function g2(x) for Trefethen transformation."""
-    return (1 / 149) * (120 + 60 * x ** 2 + 45 * x ** 4)
+    return (1 / 149) * (120 + 60 * x**2 + 45 * x**4)
 
 
 def _g3(x):
     r"""Return an auxiliary function g3(x) for Trefethen transformation."""
     return (1 / 53089) * (
-        40320 * x + 6720 * x ** 3 + 3024 * x ** 5 + 1800 * x ** 7 + 1225 * x ** 9
+        40320 * x + 6720 * x**3 + 3024 * x**5 + 1800 * x**7 + 1225 * x**9
     )
 
 
 def _derg3(x):
     r"""Return the derivative function g3(x) for Trefethen transformation."""
     return (1 / 53089) * (
-        40320 + 20160 * x ** 2 + 15120 * x ** 4 + 12600 * x ** 6 + 11025 * x ** 8
+        40320 + 20160 * x**2 + 15120 * x**4 + 12600 * x**6 + 11025 * x**8
     )
 
 
@@ -903,7 +903,7 @@ def _dergstrip(rho, s):
     # get false label
     mask_false = mask_true == 0
     u = np.arcsin(s)
-    gp[mask_true] = cn * tau ** 2 / 4 * np.tanh(tau * np.pi / 2) ** 2
+    gp[mask_true] = cn * tau**2 / 4 * np.tanh(tau * np.pi / 2) ** 2
     gp[mask_false] = (
         1 / (np.exp(tau * (np.pi / 2 + u[mask_false])) + 1)
         + 1 / (np.exp(tau * (np.pi / 2 - u[mask_false])) + 1)

--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -310,7 +310,8 @@ class RectangleRuleSineEndPoints(OneDGrid):
     """Rectangle-Rule Sine EndPoints integral quadrature class."""
 
     def __init__(self, npoints: int):
-        r"""Generate 1-D grid on [-1, 1] interval using Rectangle Rule for Sine Series (with endpoints).
+        r"""
+        Generate 1-D grid on [-1, 1] using rectangle rule for Sine Series (with endpoints).
 
         .. math::
         \int_{-1}^{1} f(x) dx \approx& \sum_{i=1}^n w_i f(x_i) \\
@@ -555,7 +556,8 @@ class ClenshawCurtis(OneDGrid):
         .. math::
         \theta_i &= \pi (i - 1) / (n - 1) \\
         x_i &= \cos (\theta_i) \\
-        w_i &= \frac{c_k}{n} \bigg(1 - \sum_{j=1}^{\lfloor n/2 \rfloor} \frac{b_j}{4j^2 - 1} \cos(2j\theta_i) \bigg)
+        w_i &= \frac{c_k}{n} \bigg(1 - \sum_{j=1}^{\lfloor n/2 \rfloor}
+            \frac{b_j}{4j^2 - 1} \cos(2j\theta_i) \bigg)
         b_j = \begin{cases}
             1 & \text{if } j = n/2 \\
             2 & \text{if } j < n/2
@@ -616,7 +618,8 @@ class FejerFirst(OneDGrid):
         .. math::
         \theta_i &= \frac{(2i - 1)\pi}{2n},
         x_i &= \cos(\theta_i),
-        w_i &= \frac{2}{n}\bigg(1 - 2 \sum_{j=1}^{\lfloor n/2 \rfloor} \frac{\cos(2j \theta_j)}{4 j^2 - 1} \bigg),
+        w_i &= \frac{2}{n}\bigg(1 - 2 \sum_{j=1}^{\lfloor n/2 \rfloor}
+            \frac{\cos(2j \theta_j)}{4 j^2 - 1} \bigg),
 
         where :math:`k=1,\cdots, n`. It uses the zeros of the Chebyshev polynomial.
         If discontinuous, it is recommended to break the intervals at the discontinuities
@@ -664,7 +667,8 @@ class FejerSecond(OneDGrid):
         .. math::
         theta_i &= k \pi / n \\
         x_i &= \cos(\theta_i) \\
-        w_i &= \frac{4 \sin(\theta_i)}{n} \sum_{j=1}^{\lfloor n/2 \rfloor} \frac{\sin(2j - 1)\theta_i}{2j - 1}\\
+        w_i &= \frac{4 \sin(\theta_i)}{n} \sum_{j=1}^{\lfloor n/2 \rfloor}
+            \frac{\sin(2j - 1)\theta_i}{2j - 1}\\
 
         where :math:`k=1, \cdots n - 1` and :math:`n` is the number of points. This
         method is considered more practical than the first method.  If discontinuous, it is
@@ -701,7 +705,7 @@ class FejerSecond(OneDGrid):
         super().__init__(points, weights, (-1, 1))
 
 
-# Auxiliar functions for Trefethen "sausage" transformation
+# Auxiliary functions for Trefethen "sausage" transformation
 # g2 is the function and derg2 is the first derivative.
 # g3 is other function with the same boundary conditions of g2 and
 # derg3 is the first derivative.
@@ -731,94 +735,135 @@ def _derg3(x):
 
 
 class TrefethenCC(OneDGrid):
-    """Trefethen CC integral quadrature class."""
+    """
+    Trefethen polynomial transformation of Clenshaw-Curtis integral quadrature class.
 
-    def __init__(self, npoints: int, d: int =3):
-        r"""Generate 1D grid on [-1,1] interval based on Trefethen-Clenshaw-Curtis.
+    References
+    ----------
+    .. [1] Hale, Nicholas, and Lloyd N. Trefethen. "New quadrature formulas from conformal maps."
+       SIAM Journal on Numerical Analysis 46.2 (2008): 930-948.
+    """
+
+    def __init__(self, npoints: int, d: int = 9):
+        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Clenshaw-Curtis.
 
         Parameters
         ----------
         npoints : int
             Number of points in the grid.
+        d :
+            Odd degree of the Taylor series polynomial of :math:`\sin^{-1}`.
+            Only d=1,5,9 are supported.
 
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
         """
         grid = ClenshawCurtis(npoints)
 
-        if d == 2:
+        if d == 1:
+            points = grid.points
+            weights = grid.weights
+        elif d == 5:
             points = _g2(grid.points)
             weights = _derg2(grid.points) * grid.weights
-        elif d == 3:
+        elif d == 9:
             points = _g3(grid.points)
             weights = _derg3(grid.points) * grid.weights
         else:
-            points = grid.points
-            weights = grid.weights
+            raise ValueError(f"Degree {d} should be either 1, 5, 9.")
 
         super().__init__(points, weights, (-1, 1))
 
 
 class TrefethenGC2(OneDGrid):
-    """Trefethen GC2 integral quadrature class."""
+    """
+    Trefethen polynomial transformation of Gauss-Chebyshev of the second kind quadrature.
 
-    def __init__(self, npoints: int, d: int=3):
+    References
+    ----------
+    .. [1] Hale, Nicholas, and Lloyd N. Trefethen. "New quadrature formulas from conformal maps."
+       SIAM Journal on Numerical Analysis 46.2 (2008): 930-948.
+    """
+
+    def __init__(self, npoints: int, d: int = 9):
         r"""Generate 1D grid on [-1,1] interval based on Trefethen-Gauss-Chebyshev.
 
         Parameters
         ----------
         npoints : int
             Number of points in the grid.
+        d : int
+            Odd degree of the Taylor series polynomial of :math:`\sin^{-1}`.
+            Only d=1,5,9 are supported.
 
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
         """
         grid = GaussChebyshevType2(npoints)
 
-        if d == 2:
+        if d == 1:
+            points = grid.points
+            weights = grid.weights
+        elif d == 5:
             points = _g2(grid.points)
             weights = _derg2(grid.points) * grid.weights
-        elif d == 3:
+        elif d == 9:
             points = _g3(grid.points)
             weights = _derg3(grid.points) * grid.weights
         else:
-            points = grid.points
-            weights = grid.weights
+            raise ValueError(f"Degree {d} should be either 1, 5, 9.")
 
         super().__init__(points, weights, (-1, 1))
 
 
 class TrefethenGeneral(OneDGrid):
-    """Trefethen General integral quadrature class."""
+    """
+    Trefethen polynomial transformation of a general integral quadrature class.
 
-    def __init__(self, npoints: int, quadrature, d=3):
-        r"""Generate 1D grid on [-1,1] interval based on Trefethen-General.
+    References
+    ----------
+    .. [1] Hale, Nicholas, and Lloyd N. Trefethen. "New quadrature formulas from conformal maps."
+       SIAM Journal on Numerical Analysis 46.2 (2008): 930-948.
+    """
+
+    def __init__(self, npoints: int, quadrature: OneDGrid, d=9):
+        r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-General.
 
         Parameters
         ----------
         npoints : int
             Number of points in the grid.
+        quadrature : OneDGrid
+            General one-dimensional grid.
+        d :
+            Odd degree of the Taylor series polynomial of :math:`\sin^{-1}`.
+            Only d=1,5,9 are supported.
 
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
         """
+        if not issubclass(quadrature, OneDGrid):
+            raise TypeError(f"Quadrature {type(OneDGrid)} should be of type OneDgrid.")
+
         grid = quadrature(npoints)
 
-        if d == 2:
+        if d == 1:
+            points = grid.points
+            weights = grid.weights
+        elif d == 5:
             points = _g2(grid.points)
             weights = _derg2(grid.points) * grid.weights
-        elif d == 3:
+        elif d == 9:
             points = _g3(grid.points)
             weights = _derg3(grid.points) * grid.weights
         else:
-            points = grid.points
-            weights = grid.weights
+            raise ValueError(f"Degree {d} should be either 1, 5, 9.")
 
         super().__init__(points, weights, (-1, 1))
 
@@ -869,7 +914,13 @@ def _dergstrip(rho, s):
 
 
 class TrefethenStripCC(OneDGrid):
-    """Trefethen Strip CC integral quadrature class."""
+    """Trefethen strip transformation of Clenshaw-Curtis quadrature.
+
+     References
+    ----------
+    .. [1] Hale, Nicholas, and Lloyd N. Trefethen. "New quadrature formulas from conformal maps."
+       SIAM Journal on Numerical Analysis 46.2 (2008): 930-948.
+    """
 
     def __init__(self, npoints: int, rho=1.1):
         r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Clenshaw-Curtis.
@@ -882,7 +933,7 @@ class TrefethenStripCC(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
         """
         grid = ClenshawCurtis(npoints)
         points = _gstrip(rho, grid.points)
@@ -892,7 +943,13 @@ class TrefethenStripCC(OneDGrid):
 
 
 class TrefethenStripGC2(OneDGrid):
-    """Trefethen Strip GC2 integral quadrature class."""
+    """Trefethen strip transformation of the Gauss-Chebyshev of the second kind quadrature.
+
+     References
+    ----------
+    .. [1] Hale, Nicholas, and Lloyd N. Trefethen. "New quadrature formulas from conformal maps."
+       SIAM Journal on Numerical Analysis 46.2 (2008): 930-948.
+    """
 
     def __init__(self, npoints: int, rho=1.1):
         r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-Gauss-Chebyshev.
@@ -905,7 +962,7 @@ class TrefethenStripGC2(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
 
         """
         grid = GaussChebyshevType2(npoints)
@@ -916,7 +973,13 @@ class TrefethenStripGC2(OneDGrid):
 
 
 class TrefethenStripGeneral(OneDGrid):
-    """Trefethen Strip General integral quadrature class."""
+    """Trefethen Strip General integral quadrature class.
+
+     References
+    ----------
+    .. [1] Hale, Nicholas, and Lloyd N. Trefethen. "New quadrature formulas from conformal maps."
+       SIAM Journal on Numerical Analysis 46.2 (2008): 930-948.
+    """
 
     def __init__(self, npoints: int, quadrature, rho=1.1):
         r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-General.
@@ -929,7 +992,7 @@ class TrefethenStripGeneral(OneDGrid):
         Returns
         -------
         OneDGrid
-            A 1D grid instance.
+            One-dimensional grid instance.
 
         """
         grid = quadrature(npoints)

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -118,12 +118,13 @@ class BeckeRTransform(BaseTransform):
     """Becke Transformation."""
 
     def __init__(self, rmin: float, R: float, trim_inf: bool = True):
-        r"""Construct Becke transform, :math:`[-1, 1]` to :math`[r_0, \inf)`.
+        r"""Construct Becke transform, :math:`[-1, 1]` to :math`[r_{min}, \inf)`.
 
         Parameters
         ----------
         rmin : float
-            The minimum coordinate :math:`r_0` in the transformed interval :math:`[r_0, \inf)`.
+            The minimum coordinate :math:`r_{min}` in the transformed interval
+            :math:`[r_{min}, \inf)`.
         R : float
             The scale factor used in the transformation.
         trim_inf : bool, optional
@@ -160,7 +161,7 @@ class BeckeRTransform(BaseTransform):
 
     @staticmethod
     def find_parameter(array: np.ndarray, rmin: float, radius: float):
-        r"""Compute R such that half of the points in :math:`[r_0, \inf)` are within radius.
+        r"""Compute R such that half of the points in :math:`[r_{min}, \inf)` are within radius.
 
         Parameters
         ----------
@@ -189,20 +190,20 @@ class BeckeRTransform(BaseTransform):
         return (radius - rmin) * (1 - mid_value) / (1 + mid_value)
 
     def transform(self, x: np.ndarray):
-        r"""Transform from :math:`[-1, 1]` to :math:`[r_0, \inf)`.
+        r"""Transform from :math:`[-1, 1]` to :math:`[r_{min}, \inf)`.
 
         .. math::
-            r_i = R \frac{1 + x_i}{1 - x_i} + r_{0}
+            r_i = R \frac{1 + x_i}{1 - x_i} + r_{min}
 
         Parameters
         ----------
         x : np.ndarray(N,)
-            One-dimensional array located between [-1, 1].
+            One-dimensional array in the domain :math:`[-1, 1]`.
 
         Returns
         -------
         np.ndarray(N,)
-            Transformed array located between :math:`[r_0, \inf)`.
+            Transformed array located between :math:`[r_min, \inf)`.
 
         """
         with warnings.catch_warnings():
@@ -213,25 +214,25 @@ class BeckeRTransform(BaseTransform):
         return rf_array
 
     def inverse(self, r: np.ndarray):
-        r"""Transform :math:`[r_0, \inf)` back to original :math:`[-1, 1]`.
+        r"""Transform :math:`[r_{mi}n, \inf)` back to original :math:`[-1, 1]`.
 
         .. math::
-            x_i = \frac{r_i - r_{0} - R} {r_i - r_{0} + R}
+            x_i = \frac{r_i - r_{min} - R} {r_i - r_{min} + R}
 
         Parameters
         ----------
         r : np.ndarray(N,)
-            Sorted one dimension array located between :math:`[r_0, \inf)`.
+            One-dimensional array in the codomain :math:`[r_{min}, \inf)`.
 
         Returns
         -------
         np.ndarray(N,)
-            The original one dimension array located between [-1, 1].
+            One dimensional array in :math:`[-1, 1]`.
         """
         return (r - self._rmin - self._R) / (r - self._rmin + self._R)
 
     def deriv(self, x: np.ndarray):
-        r"""Compute the 1st derivative of Becke transformation.
+        r"""Compute the first derivative of Becke transformation.
 
         .. math::
             \frac{dr_i}{dx_i} = 2R \frac{1}{(1-x)^2}
@@ -239,12 +240,12 @@ class BeckeRTransform(BaseTransform):
         Parameters
         ----------
         x : np.array(N,)
-            One dimension numpy array located between [-1, 1]
+            One-dimensional array in the domain :math:`[-1, 1]`.
 
         Returns
         -------
         np.ndarray(N,)
-            1st derivative of Becke transformation at each points
+            First derivative of Becke transformation at each point.
         """
         return 2 * self._R / ((1 - x) ** 2)
 
@@ -257,12 +258,12 @@ class BeckeRTransform(BaseTransform):
         Parameters
         ----------
         x : np.array(N,)
-            One dimension numpy array located between [-1, 1]
+            One-dimensional array in the domain :math:`[-1, 1]`.
 
         Returns
         -------
         np.ndarray(N,)
-            Second derivative of Becke transformation at each points
+            Second derivative of Becke transformation at each point.
         """
         return 4 * self._R / (1 - x) ** 3
 
@@ -275,12 +276,12 @@ class BeckeRTransform(BaseTransform):
         Parameters
         ----------
         x : np.array(N,)
-            One dimension numpy array located between [-1, 1]
+            One-dimensional array in the domain :math:`[-1, 1]`.
 
         Returns
         -------
         np.ndarray(N,)
-            Third derivative of Becke transformation at each points
+            Third derivative of Becke transformation at each point.
         """
         return 12 * self._R / (1 - x) ** 4
 

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -63,22 +63,24 @@ class BaseTransform(ABC):
         return self._codomain
 
     def transform_1d_grid(self, oned_grid):
-        r"""Generate a new integral grid by transforming given the OneDGrid.
+        r"""Generate a new integral grid by transforming the provided grid.
 
         .. math::
-            \int^{\inf}_0 g(r) d r &= \int^b_a g(r(x)) \frac{dr}{dx} dx \\
-                                   &= \int^b_a f(x) \frac{dr}{dx} dx \\
-            w^r_n = w^x_n \cdot \frac{dr}{dx} \vert_{x_n}
+            \int^{\inf}_0 g(r) d r &= \int^{r(\infty)}_{r(0)} g(r(x)) \frac{dr}{dx} dx \\
+                                   &= \int^{r(\infty)}_{r(0)} g(r(x)) \frac{dr}{dx} dx \\
+                                   &\approx \sum_{i=1}^N g(r(x_i)) \frac{dr}{dx}(x_i) w_i  \\
+                                   &\approx \sum_{i=1}^N g(r(x_i)) \frac{dr}{dx}(x_i) w^r_n \\
+            w^r_n &= w^x_n \cdot \frac{dr}{dx}
 
         Parameters
         ----------
         oned_grid : OneDGrid
-            An instance of 1D grid.
+            An instance of one-dimensional grid.
 
         Returns
         -------
         OneDGrid
-            Transformed 1D grid spanning a different domain.
+            Transformed one-dimensional grid spanning a different domain.
 
         """
         if not isinstance(oned_grid, OneDGrid):

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -285,8 +285,8 @@ class BeckeRTransform(BaseTransform):
         return 12 * self._R / (1 - x) ** 4
 
 
-class LinearTF(BaseTransform):
-    """Linear transformation class."""
+class LinearFiniteTF(BaseTransform):
+    """Linear transformation from :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`."""
 
     def __init__(self, rmin: float, rmax: float):
         """Construct linear transformation instance.
@@ -399,8 +399,8 @@ class LinearTF(BaseTransform):
         return (2 * r - (self._rmax + self._rmin)) / (self._rmax - self._rmin)
 
 
-class InverseTF(BaseTransform):
-    """Inverse transformation class, [rmin, rmax] or [rmin, inf) -> [-1, 1]."""
+class InverseRTransform(BaseTransform):
+    """Inverse transformation class for any general transformation."""
 
     def __init__(self, transform: BaseTransform):
         """Construct InverseRTransform instance.
@@ -646,8 +646,10 @@ class IdentityRTransform(BaseTransform):
         return r
 
 
-class LinearRTransform(BaseTransform):
-    """Linear transform class."""
+class LinearInfiniteRTransform(BaseTransform):
+    """
+    Linear transform from large interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`.
+    """
 
     def __init__(self, rmin: float, rmax: float):
         """Initialize linear transform class.

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -118,13 +118,13 @@ class BeckeRTransform(BaseTransform):
     """Becke Transformation."""
 
     def __init__(self, rmin: float, R: float, trim_inf: bool = True):
-        r"""Construct Becke transform, :math:`[-1, 1]` to :math`[r_{min}, \inf)`.
+        r"""Construct Becke transform, :math:`[-1, 1]` to :math`[r_{min}, \infty)`.
 
         Parameters
         ----------
         rmin : float
             The minimum coordinate :math:`r_{min}` in the transformed interval
-            :math:`[r_{min}, \inf)`.
+            :math:`[r_{min}, \infty)`.
         R : float
             The scale factor used in the transformation.
         trim_inf : bool, optional
@@ -161,7 +161,7 @@ class BeckeRTransform(BaseTransform):
 
     @staticmethod
     def find_parameter(array: np.ndarray, rmin: float, radius: float):
-        r"""Compute R such that half of the points in :math:`[r_{min}, \inf)` are within radius.
+        r"""Compute R such that half of the points in :math:`[r_{min}, \infty)` are within radius.
 
         Parameters
         ----------
@@ -190,7 +190,7 @@ class BeckeRTransform(BaseTransform):
         return (radius - rmin) * (1 - mid_value) / (1 + mid_value)
 
     def transform(self, x: np.ndarray):
-        r"""Transform from :math:`[-1, 1]` to :math:`[r_{min}, \inf)`.
+        r"""Transform from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`.
 
         .. math::
             r_i = R \frac{1 + x_i}{1 - x_i} + r_{min}
@@ -203,7 +203,7 @@ class BeckeRTransform(BaseTransform):
         Returns
         -------
         np.ndarray(N,)
-            Transformed array located between :math:`[r_min, \inf)`.
+            Transformed array located between :math:`[r_min, \infty)`.
 
         """
         with warnings.catch_warnings():
@@ -214,7 +214,7 @@ class BeckeRTransform(BaseTransform):
         return rf_array
 
     def inverse(self, r: np.ndarray):
-        r"""Transform :math:`[r_{mi}n, \inf)` back to original :math:`[-1, 1]`.
+        r"""Transform :math:`[r_{mi}n, \infty)` back to original :math:`[-1, 1]`.
 
         .. math::
             x_i = \frac{r_i - r_{min} - R} {r_i - r_{min} + R}
@@ -222,7 +222,7 @@ class BeckeRTransform(BaseTransform):
         Parameters
         ----------
         r : np.ndarray(N,)
-            One-dimensional array in the codomain :math:`[r_{min}, \inf)`.
+            One-dimensional array in the codomain :math:`[r_{min}, \infty)`.
 
         Returns
         -------

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -93,7 +93,9 @@ class BaseTransform(ABC):
         new_weights = self.deriv(oned_grid.points) * oned_grid.weights
         new_domain = oned_grid.domain
         if new_domain is not None:
-            new_domain = self.transform(np.array(oned_grid.domain))
+            # Some transformation (Issue #125) reverses the order of points i.e.
+            #    [-1, 1] maps to [infinity, 0].  This sort here fixes the problem here.
+            new_domain = tuple(np.sort(self.transform(np.array(oned_grid.domain))))
         return OneDGrid(new_points, new_weights, new_domain)
 
     def _convert_inf(self, array, replace_inf=1e16):

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -648,7 +648,7 @@ class IdentityRTransform(BaseTransform):
 
 
 class LinearInfiniteRTransform(BaseTransform):
-    r"""Linear transform from large interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`."""
+    r"""Linear transform from interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`."""
 
     def __init__(self, rmin: float, rmax: float):
         r"""Initialize linear transform class.

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -118,7 +118,7 @@ class BeckeRTransform(BaseTransform):
     """Becke Transformation."""
 
     def __init__(self, rmin: float, R: float, trim_inf: bool = True):
-        """Construct Becke transform, :math:`[-1, 1]` to :math`[r_0, \inf)`.
+        r"""Construct Becke transform, :math:`[-1, 1]` to :math`[r_0, \inf)`.
 
         Parameters
         ----------
@@ -160,7 +160,7 @@ class BeckeRTransform(BaseTransform):
 
     @staticmethod
     def find_parameter(array: np.ndarray, rmin: float, radius: float):
-        """Compute R such that half of the points in :math:`[r_0, \inf)` are within radius.
+        r"""Compute R such that half of the points in :math:`[r_0, \inf)` are within radius.
 
         Parameters
         ----------
@@ -304,7 +304,7 @@ class LinearFiniteTF(BaseTransform):
         self._codomain = (rmin, rmax)
 
     def transform(self, x: np.ndarray):
-        r"""Transform from interval :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`
+        r"""Transform from interval :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`.
 
         .. math::
             r_i = \frac{r_{max} - r_{min}}{2} (1 + x_i) + r_{min}.
@@ -558,7 +558,7 @@ class IdentityRTransform(BaseTransform):
         self._codomain = (0, np.inf)
 
     def transform(self, x: np.ndarray):
-        """
+        r"""
         Perform given array into itself.
 
         .. math::
@@ -578,7 +578,7 @@ class IdentityRTransform(BaseTransform):
         return x
 
     def deriv(self, x: np.ndarray):
-        """
+        r"""
         Compute the first derivative of identity transform.
 
         Parameters
@@ -595,7 +595,7 @@ class IdentityRTransform(BaseTransform):
         return 1 if isinstance(x, Number) else np.ones(x.size)
 
     def deriv2(self, x: np.ndarray):
-        """
+        r"""
         Compute the second derivative of identity transform.
 
         Parameters
@@ -612,7 +612,7 @@ class IdentityRTransform(BaseTransform):
         return 0 if isinstance(x, Number) else np.zeros(x.size)
 
     def deriv3(self, x: np.ndarray):
-        """
+        r"""
         Compute the third derivative of identity transform.
 
         Parameters
@@ -629,7 +629,7 @@ class IdentityRTransform(BaseTransform):
         return 0 if isinstance(x, Number) else np.zeros(x.size)
 
     def inverse(self, r: np.ndarray):
-        """
+        r"""
         Compute the inverse of identity transform.
 
         Parameters
@@ -647,12 +647,10 @@ class IdentityRTransform(BaseTransform):
 
 
 class LinearInfiniteRTransform(BaseTransform):
-    """
-    Linear transform from large interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`.
-    """
+    r"""Linear transform from large interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`."""
 
     def __init__(self, rmin: float, rmax: float):
-        """Initialize linear transform class.
+        r"""Initialize linear transform class.
 
         Parameters
         ----------
@@ -673,16 +671,16 @@ class LinearInfiniteRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: rmin value of the tf."""
+        r"""float: rmin value of the tf."""
         return self._rmin
 
     @property
     def rmax(self):
-        """float: rmax value of the tf."""
+        r"""float: rmax value of the tf."""
         return self._rmax
 
     def transform(self, x: np.ndarray):
-        """Transform from interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`.
+        r"""Transform from interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`.
 
         .. math::
             r_i = \frac{(r_{max} - r_{min})}{N - 1} x + r_{min},
@@ -705,7 +703,7 @@ class LinearInfiniteRTransform(BaseTransform):
         return alpha * x + self._rmin
 
     def deriv(self, x: np.ndarray):
-        """
+        r"""
         Compute the first derivative of linear transformation.
 
         Parameters
@@ -723,7 +721,7 @@ class LinearInfiniteRTransform(BaseTransform):
         return np.ones(x.size) * alpha
 
     def deriv2(self, x: np.ndarray):
-        """Compute the second derivative of linear transformation.
+        r"""Compute the second derivative of linear transformation.
 
         Parameters
         ----------
@@ -739,7 +737,7 @@ class LinearInfiniteRTransform(BaseTransform):
         return np.zeros(x.size)
 
     def deriv3(self, x: np.ndarray):
-        """Compute the third derivative of linear transformation.
+        r"""Compute the third derivative of linear transformation.
 
         Parameters
         ----------
@@ -755,7 +753,7 @@ class LinearInfiniteRTransform(BaseTransform):
         return np.zeros(x.size)
 
     def inverse(self, r: np.ndarray):
-        """Compute the inverse of linear transformation.
+        r"""Compute the inverse of linear transformation.
 
         .. math::
             x_i = (r - r_{min}) \frac{N - 1}{r_{max} - r_{min}}
@@ -776,10 +774,10 @@ class LinearInfiniteRTransform(BaseTransform):
 
 
 class ExpRTransform(BaseTransform):
-    """Exponential transform from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`."""
+    r"""Exponential transform from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`."""
 
     def __init__(self, rmin: float, rmax: float):
-        """Initialize exp transform instance.
+        r"""Initialize exp transform instance.
 
         Parameters
         ----------
@@ -804,16 +802,16 @@ class ExpRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: the value of rmin."""
+        r"""float: the value of rmin."""
         return self._rmin
 
     @property
     def rmax(self):
-        """float: the value of rmax."""
+        r"""float: the value of rmax."""
         return self._rmax
 
     def transform(self, x: np.ndarray):
-        """
+        r"""
         Perform exponential transform.
 
         .. math::
@@ -836,7 +834,7 @@ class ExpRTransform(BaseTransform):
         return self._rmin * np.exp(x * alpha)
 
     def deriv(self, x: np.ndarray):
-        """
+        r"""
         Compute the first derivative of exponential transform.
 
         Parameters
@@ -854,7 +852,7 @@ class ExpRTransform(BaseTransform):
         return self.transform(x) * alpha
 
     def deriv2(self, x: np.ndarray):
-        """
+        r"""
         Compute the second derivative of exponential transform.
 
         Parameters
@@ -872,7 +870,7 @@ class ExpRTransform(BaseTransform):
         return self.deriv(x) * alpha
 
     def deriv3(self, x: np.ndarray):
-        """
+        r"""
         Compute the third derivative of exponential transform.
 
         Parameters
@@ -890,7 +888,7 @@ class ExpRTransform(BaseTransform):
         return self.deriv2(x) * alpha
 
     def inverse(self, r: np.ndarray):
-        """
+        r"""
         Compute the inverse of exponential transform.
 
         Parameters
@@ -909,10 +907,10 @@ class ExpRTransform(BaseTransform):
 
 
 class PowerRTransform(BaseTransform):
-    """Power transform class from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`."""
+    r"""Power transform class from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`."""
 
     def __init__(self, rmin: float, rmax: float):
-        """Initialize power transform instance.
+        r"""Initialize power transform instance.
 
         Parameters
         ----------
@@ -933,16 +931,16 @@ class PowerRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: the value of rmin."""
+        r"""float: the value of rmin."""
         return self._rmin
 
     @property
     def rmax(self):
-        """float: the value of rmax."""
+        r"""float: the value of rmax."""
         return self._rmax
 
     def transform(self, x: np.ndarray):
-        """
+        r"""
         Perform power transform.
 
         .. math::
@@ -969,7 +967,7 @@ class PowerRTransform(BaseTransform):
         return self._rmin * np.power(x + 1, power)
 
     def deriv(self, x: np.ndarray):
-        """
+        r"""
         Compute first derivative of power transform.
 
         Parameters
@@ -987,7 +985,7 @@ class PowerRTransform(BaseTransform):
         return power * self._rmin * np.power(x + 1, power - 1)
 
     def deriv2(self, x: np.ndarray):
-        """
+        r"""
         Compute second derivative of power transform.
 
         Parameters
@@ -1005,7 +1003,7 @@ class PowerRTransform(BaseTransform):
         return power * (power - 1) * self._rmin * np.power(x + 1, power - 2)
 
     def deriv3(self, x: np.ndarray):
-        """
+        r"""
         Compute third derivative of power transform.
 
         Parameters
@@ -1025,7 +1023,7 @@ class PowerRTransform(BaseTransform):
         )
 
     def inverse(self, r: np.ndarray):
-        """
+        r"""
         Compute the inverse of power transform.
 
         Parameters
@@ -1044,10 +1042,10 @@ class PowerRTransform(BaseTransform):
 
 
 class HyperbolicRTransform(BaseTransform):
-    """Hyperbolic transform from :math`[0, \infty)` to :math:`[0, \infty)`."""
+    r"""Hyperbolic transform from :math`[0, \infty)` to :math:`[0, \infty)`."""
 
     def __init__(self, a: float, b: float):
-        """Hyperbolic transform class.
+        r"""Hyperbolic transform class.
 
         Parameters
         ----------
@@ -1068,16 +1066,16 @@ class HyperbolicRTransform(BaseTransform):
 
     @property
     def a(self):
-        """float: value of parameter a."""
+        r"""float: value of parameter a."""
         return self._a
 
     @property
     def b(self):
-        """float: value of parameter b."""
+        r"""float: value of parameter b."""
         return self._b
 
     def transform(self, x: np.ndarray):
-        """Perform hyperbolic transformation.
+        r"""Perform hyperbolic transformation.
 
         .. math::
             r_i = \frac{a x}{(1 - bx)},
@@ -1095,13 +1093,12 @@ class HyperbolicRTransform(BaseTransform):
             The transformation of x to the co-domain of the transformation.
 
         """
-
         if self._b * (x.size - 1) >= 1.0:
             raise ValueError("b*(npoint-1) must be smaller than one.")
         return self._a * x / (1 - self._b * x)
 
     def deriv(self, x: np.ndarray):
-        """
+        r"""
         Compute the first derivative of hyperbolic transformation.
 
         Parameters
@@ -1121,7 +1118,7 @@ class HyperbolicRTransform(BaseTransform):
         return self._a * x * x
 
     def deriv2(self, x: np.ndarray):
-        """
+        r"""
         Compute the second derivative of hyperbolic transformation.
 
         Parameters
@@ -1138,10 +1135,10 @@ class HyperbolicRTransform(BaseTransform):
         if self._b * (x.size - 1) >= 1.0:
             raise ValueError("b*(npoint-1) must be smaller than one.")
         x = 1.0 / (1 - self._b * x)
-        return 2.0 * self._a * self._b * x ** 3
+        return 2.0 * self._a * self._b * x**3
 
     def deriv3(self, x: np.ndarray):
-        """
+        r"""
         Compute the third derivative of hyperbolic transformation.
 
         Parameters
@@ -1158,10 +1155,10 @@ class HyperbolicRTransform(BaseTransform):
         if self._b * (x.size - 1) >= 1.0:
             raise ValueError("b*(npoint-1) must be smaller than one.")
         x = 1.0 / (1 - self._b * x)
-        return 6.0 * self._a * self._b * self._b * x ** 4
+        return 6.0 * self._a * self._b * self._b * x**4
 
     def inverse(self, r: np.ndarray):
-        """
+        r"""
         Compute the inverse of hyperbolic transformation.
 
         Parameters
@@ -1181,7 +1178,7 @@ class HyperbolicRTransform(BaseTransform):
 
 
 class MultiExpRTransform(BaseTransform):
-    """
+    r"""
     MultiExp Transformation class.
 
     References
@@ -1192,7 +1189,7 @@ class MultiExpRTransform(BaseTransform):
     """
 
     def __init__(self, rmin: float, R: float, trim_inf=True):
-        """Construct MultiExp transform from :math:`[-1,1]` to :math:`[r_{min}, \infty)`.
+        r"""Construct MultiExp transform from :math:`[-1,1]` to :math:`[r_{min}, \infty)`.
 
         Parameters
         ----------
@@ -1213,12 +1210,12 @@ class MultiExpRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: The minimum value for the transformed radial array."""
+        r"""float: The minimum value for the transformed radial array."""
         return self._rmin
 
     @property
     def R(self):
-        """float: The scale factor for the transformed radial array."""
+        r"""float: The scale factor for the transformed radial array."""
         return self._R
 
     def transform(self, x: np.ndarray):
@@ -1322,10 +1319,10 @@ class MultiExpRTransform(BaseTransform):
 
 
 class KnowlesRTransform(BaseTransform):
-    """Knowles Transformation from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`."""
+    r"""Knowles Transformation from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`."""
 
     def __init__(self, rmin: float, R: float, k: int, trim_inf=True):
-        """Construct Knowles transformation class.
+        r"""Construct Knowles transformation class.
 
         Parameters
         ----------
@@ -1352,17 +1349,17 @@ class KnowlesRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: The minimum value for the transformed radial array."""
+        r"""float: The minimum value for the transformed radial array."""
         return self._rmin
 
     @property
     def R(self):
-        """float: The scale factor for the transformed radial array."""
+        r"""float: The scale factor for the transformed radial array."""
         return self._R
 
     @property
     def k(self):
-        """float: Free and extra parameter, k must be > 0."""
+        r"""float: Free and extra parameter, k must be > 0."""
         return self._k
 
     def transform(self, x: np.ndarray):
@@ -1383,7 +1380,7 @@ class KnowlesRTransform(BaseTransform):
 
         """
         rf_array = (
-            -self._R * np.log(1 - (2 ** -self._k) * (x + 1) ** self._k) + self._rmin
+            -self._R * np.log(1 - (2**-self._k) * (x + 1) ** self._k) + self._rmin
         )
         if self.trim_inf:
             rf_array = self._convert_inf(rf_array)
@@ -1427,7 +1424,7 @@ class KnowlesRTransform(BaseTransform):
         """
         qi = 1 + x
         return (
-            self._R * self._k * (qi ** (self._k - 1)) / (2 ** self._k - qi ** self._k)
+            self._R * self._k * (qi ** (self._k - 1)) / (2**self._k - qi**self._k)
         )
 
     def deriv2(self, x: np.ndarray):
@@ -1453,8 +1450,8 @@ class KnowlesRTransform(BaseTransform):
             self._R
             * self._k
             * (qi ** (self._k - 2))
-            * (2 ** self._k * (self._k - 1) + qi ** self._k)
-            / (2 ** self._k - qi ** self._k) ** 2
+            * (2**self._k * (self._k - 1) + qi**self._k)
+            / (2**self._k - qi**self._k) ** 2
         )
 
     def deriv3(self, x: np.ndarray):
@@ -1483,19 +1480,19 @@ class KnowlesRTransform(BaseTransform):
             * self._k
             * (qi ** (self._k - 3))
             * (
-                4 ** self._k * (self._k - 2) * (self._k - 1)
-                + 2 ** self._k * (self._k - 1) * (self._k + 4) * (qi ** self._k)
+                4**self._k * (self._k - 2) * (self._k - 1)
+                + 2**self._k * (self._k - 1) * (self._k + 4) * (qi**self._k)
                 + 2 * qi ** (2 * self._k)
             )
-            / (2 ** self._k - qi ** self._k) ** 3
+            / (2**self._k - qi**self._k) ** 3
         )
 
 
 class HandyRTransform(BaseTransform):
-    """Handy Transformation class from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`."""
+    r"""Handy Transformation class from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`."""
 
     def __init__(self, rmin: float, R: float, m: int, trim_inf=True):
-        """Construct Handy transformation.
+        r"""Construct Handy transformation.
 
         Parameters
         ----------
@@ -1522,17 +1519,17 @@ class HandyRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: The minimum value for the transformed radial array."""
+        r"""float: The minimum value for the transformed radial array."""
         return self._rmin
 
     @property
     def R(self):
-        """float: The scale factor for the transformed radial array."""
+        r"""float: The scale factor for the transformed radial array."""
         return self._R
 
     @property
     def m(self):
-        """integer: Free and extra parameter, m must be > 0."""
+        r"""integer: Free and extra parameter, m must be > 0."""
         return self._m
 
     def transform(self, x: np.ndarray):
@@ -1651,7 +1648,7 @@ class HandyRTransform(BaseTransform):
             4
             * self._m
             * self._R
-            * (1 + 6 * self._m * x + 2 * self._m ** 2 + 3 * x ** 2)
+            * (1 + 6 * self._m * x + 2 * self._m**2 + 3 * x**2)
             * (1 + x) ** (self._m - 3)
             / (1 - x) ** (self._m + 3)
         )
@@ -1662,10 +1659,10 @@ class HandyRTransform(BaseTransform):
 
 
 class HandyModRTransform(BaseTransform):
-    """Modified Handy Transformation class."""
+    r"""Modified Handy Transformation class."""
 
     def __init__(self, rmin: float, rmax: float, m: int, trim_inf=True):
-        """Construct a modified Handy transform [-1,1] -> [rmin,rmax].
+        r"""Construct a modified Handy transform [-1,1] -> [rmin,rmax].
 
         Parameters
         ----------
@@ -1696,17 +1693,17 @@ class HandyModRTransform(BaseTransform):
 
     @property
     def rmin(self):
-        """float: The minimum value for the transformed radial array."""
+        r"""float: The minimum value for the transformed radial array."""
         return self._rmin
 
     @property
     def rmax(self):
-        """float: The maximum value for the transformed radial array."""
+        r"""float: The maximum value for the transformed radial array."""
         return self._rmax
 
     @property
     def m(self):
-        """integer: Free and extra parameter, m must be > 0."""
+        r"""integer: Free and extra parameter, m must be > 0."""
         return self._m
 
     def transform(self, x: np.ndarray):
@@ -1728,7 +1725,7 @@ class HandyModRTransform(BaseTransform):
             One dimensional array in :math:`[r_{min},r_{max}]`.
 
         """
-        two_m = 2 ** self._m
+        two_m = 2**self._m
         size_r = self._rmax - self._rmin
         qi = (1 + x) ** self._m
 
@@ -1759,7 +1756,7 @@ class HandyModRTransform(BaseTransform):
             The original one dimensional array in :math:`[-1,1]`.
 
         """
-        two_m = 2 ** self._m
+        two_m = 2**self._m
         size_r = self._rmax - self._rmin
 
         tmp_r = (
@@ -1790,7 +1787,7 @@ class HandyModRTransform(BaseTransform):
             The first derivative of Handy transformation at each point.
 
         """
-        two_m = 2 ** self._m
+        two_m = 2**self._m
         size_r = self._rmax - self._rmin
         return (
             -(
@@ -1817,7 +1814,7 @@ class HandyModRTransform(BaseTransform):
         ndarrray(N,)
             The second derivative of Handy transformation at each point.
         """
-        two_m = 2 ** self._m
+        two_m = 2**self._m
         size_r = self._rmax - self._rmin
         return (
             -(
@@ -1848,7 +1845,7 @@ class HandyModRTransform(BaseTransform):
         ndarrray(N,)
             The third derivative of Handy transformation at each point.
         """
-        two_m = 2 ** self._m
+        two_m = 2**self._m
         size_r = self._rmax - self._rmin
         return (
             -(

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -285,7 +285,7 @@ class BeckeRTransform(BaseTransform):
         return 12 * self._R / (1 - x) ** 4
 
 
-class LinearFiniteTF(BaseTransform):
+class LinearFiniteRTransform(BaseTransform):
     """Linear transformation from :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`."""
 
     def __init__(self, rmin: float, rmax: float):

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -117,7 +117,26 @@ class BaseTransform(ABC):
 
 
 class BeckeRTransform(BaseTransform):
-    """Becke Transformation."""
+    """
+    Becke Transformation.
+
+    The Becke transformation transforms from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`
+    according to
+
+    .. math::
+        r(x) = R \frac{1 + x}{1 - x} + r_{min}.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) = \frac{r - r_{min} - R} {r - r_{min} + R}.
+
+    References
+    ----------
+    .. [1] Becke, Axel D. "A multicenter numerical integration scheme for polyatomic molecules."
+       The Journal of chemical physics 88.4 (1988): 2547-2553.
+
+    """
 
     def __init__(self, rmin: float, R: float, trim_inf: bool = True):
         r"""Construct Becke transform, :math:`[-1, 1]` to :math`[r_{min}, \infty)`.
@@ -163,7 +182,8 @@ class BeckeRTransform(BaseTransform):
 
     @staticmethod
     def find_parameter(array: np.ndarray, rmin: float, radius: float):
-        r"""Compute R such that half of the points in :math:`[r_{min}, \infty)` are within radius.
+        r"""
+        Compute R such that half of the points in :math:`[r_{min}, \infty)` are within radius.
 
         Parameters
         ----------
@@ -289,7 +309,21 @@ class BeckeRTransform(BaseTransform):
 
 
 class LinearFiniteRTransform(BaseTransform):
-    """Linear transformation from :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`."""
+    """
+    Linear finite transformation from :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`.
+
+    The Linear transformation from finite interval :math:`[-1, 1]` to finite interval
+    :math:`[r_{min}, r_{max}]` is given by
+
+    .. math::
+        r(x) = \frac{r_{max} - r_{min}}{2} (1 + x) + r_{min}.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) = \frac{2 r - (r_{max} + r_{min})}{r_{max} - r_{min}}
+
+    """
 
     def __init__(self, rmin: float, rmax: float):
         """Construct linear transformation instance.
@@ -554,7 +588,21 @@ class InverseRTransform(BaseTransform):
 
 
 class IdentityRTransform(BaseTransform):
-    """Identity Transform class."""
+    """
+    Identity Transform class.
+
+    The identity transform class trivially transforms from :math:`[0, \infty)` to
+    :math:`[0, \infty)` given by
+
+    .. math::
+        r(x) = x.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) = r.
+
+    """
 
     def __init__(self):
         self._domain = (0, np.inf)
@@ -650,7 +698,21 @@ class IdentityRTransform(BaseTransform):
 
 
 class LinearInfiniteRTransform(BaseTransform):
-    r"""Linear transform from interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`."""
+    r"""
+    Linear transform from interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max})`.
+
+    This transformation linearly maps the infinite interval :math:`[0, \infty)` to a finite
+    interval :math:`[r_{min}, r_{max}]` given by
+
+    .. math::
+        r(x) = \frac{(r_{max} - r_{min})}{N - 1} x + r_{min},
+
+    The inverse is given by
+
+    .. math::
+        x(r) = (r - r_{min}) \frac{N - 1}{r_{max} - r_{min}}
+
+    """
 
     def __init__(self, rmin: float, rmax: float):
         r"""Initialize linear transform class.
@@ -686,7 +748,7 @@ class LinearInfiniteRTransform(BaseTransform):
         r"""Transform from interval :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`.
 
         .. math::
-            r_i = \frac{(r_{max} - r_{min})}{N - 1} x + r_{min},
+            r_i = \frac{(r_{max} - r_{min})}{N - 1} x_i + r_{min},
 
         where :math:`N` is the number of points. The goal is to transform
         equally-spaced integers from 0 to N-1, to :math:`[r_{min}, r_{max}]`.
@@ -777,7 +839,19 @@ class LinearInfiniteRTransform(BaseTransform):
 
 
 class ExpRTransform(BaseTransform):
-    r"""Exponential transform from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`."""
+    r"""
+    Exponential transform from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`.
+
+    This transformation is given by
+
+    .. math::
+        r(x) = r_{min} e^{x \log\bigg(\frac{r_{max}}{r_{min} / (N - 1)}  \bigg)}.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) = \frac{\log\big(\frac{r}{r_{min}} \big) (N - 1)}{\log(\frac{r_{max}}{r_{min}})}
+    """
 
     def __init__(self, rmin: float, rmax: float):
         r"""Initialize exp transform instance.
@@ -894,6 +968,9 @@ class ExpRTransform(BaseTransform):
         r"""
         Compute the inverse of exponential transform.
 
+        .. math::
+            x(r_i) = \frac{\log\big(\frac{r}{r_{min}} \big) (N - 1)}{\log(\frac{r_{max}}{r_{min}})}
+
         Parameters
         ----------
         r : ndarray(N,)
@@ -910,7 +987,20 @@ class ExpRTransform(BaseTransform):
 
 
 class PowerRTransform(BaseTransform):
-    r"""Power transform class from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`."""
+    r"""
+    Power transform class from :math:`[0, \infty)` to :math:`[r_{min}, r_{max}]`.
+
+    This transformations is given by
+
+    .. math::
+        r(x) = r_{min}  (x + 1)^{\frac{\log(r_{max} - \log(r_{min}}{N}}.
+
+    The inverse of the transformation is given by
+
+    .. math::
+         x(r) = \frac{r}{r_{min}}^{\frac{\log(N)}{\log(r_{max}) - \log(r_{min})}} - 1.
+
+    """
 
     def __init__(self, rmin: float, rmax: float):
         r"""Initialize power transform instance.
@@ -1029,6 +1119,9 @@ class PowerRTransform(BaseTransform):
         r"""
         Compute the inverse of power transform.
 
+        .. math::
+            x(r) = \frac{r}{r_{min}}^{\frac{\log(N)}{\log(r_{max}) - \log(r_{min})}} - 1
+
         Parameters
         ----------
         r : ndarray(N,)
@@ -1045,7 +1138,22 @@ class PowerRTransform(BaseTransform):
 
 
 class HyperbolicRTransform(BaseTransform):
-    r"""Hyperbolic transform from :math`[0, \infty)` to :math:`[0, \infty)`."""
+    r"""
+    Hyperbolic transform from :math`[0, \infty)` to :math:`[0, \infty)`.
+
+    The transformation is given by
+
+    .. math::
+        r(x) = \frac{a x}{(1 - bx)},
+
+    where :math:`b ( N - 1) \geq 1`, and :math:`N` is the number of points in x.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) = \frac{r}{a + br}
+
+    """
 
     def __init__(self, a: float, b: float):
         r"""Hyperbolic transform class.
@@ -1081,7 +1189,7 @@ class HyperbolicRTransform(BaseTransform):
         r"""Perform hyperbolic transformation.
 
         .. math::
-            r_i = \frac{a x}{(1 - bx)},
+            r_i = \frac{a x_i}{(1 - bx_i)},
 
         where :math:`b ( N - 1) \geq 1`, and :math:`N` is the number of points in x.
 
@@ -1164,6 +1272,9 @@ class HyperbolicRTransform(BaseTransform):
         r"""
         Compute the inverse of hyperbolic transformation.
 
+        .. math::
+            x(r) = \frac{r}{a + br}
+
         Parameters
         ----------
         r : ndarray(N,)
@@ -1182,7 +1293,17 @@ class HyperbolicRTransform(BaseTransform):
 
 class MultiExpRTransform(BaseTransform):
     r"""
-    MultiExp Transformation class.
+    MultiExp Transformation class from :math:`[-1,1]` to :math:`[r_{min}, \infty)`.
+
+    The transformation is given by
+
+    .. math::
+        r(x) = -R \log \left( \frac{x + 1}{2} \right) + r_{min}
+
+    The inverse of this transformation is given by
+
+    .. math::
+        x(r) = 2 \exp \left( \frac{-(r - r_{min})}{R} \right) - 1
 
     References
     ----------
@@ -1322,7 +1443,22 @@ class MultiExpRTransform(BaseTransform):
 
 
 class KnowlesRTransform(BaseTransform):
-    r"""Knowles Transformation from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`."""
+    r"""
+    Knowles Transformation from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`.
+
+    The transformation is given by
+
+    .. math::
+       r(x) = r_{min} - R \log \left( 1 - 2^{-k} (x + 1)^k \right),
+
+    where :math:`k > 0` and :math:`R` is the scaling parameter.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) = 2 \sqrt[k]{1-\exp \left( -\frac{r-r_{min}}{R}\right)}-1
+
+    """
 
     def __init__(self, rmin: float, R: float, k: int, trim_inf=True):
         r"""Construct Knowles transformation class.
@@ -1492,7 +1628,20 @@ class KnowlesRTransform(BaseTransform):
 
 
 class HandyRTransform(BaseTransform):
-    r"""Handy Transformation class from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`."""
+    r"""
+    Handy Transformation class from :math:`[-1, 1]` to :math:`[r_{min}, \infty)`.
+
+    This transformation is given by
+
+    .. math::
+        r(x) = R \left( \frac{1+x}{1-x} \right)^m + r_{min}.
+
+    The inverse transformations is given by
+
+    .. math::
+        x(r) = \frac{\sqrt[m]{r-r_{min}} - \sqrt[m]{R}} {\sqrt[m]{r-r_{min}} + \sqrt[m]{R}}.
+
+    """
 
     def __init__(self, rmin: float, R: float, m: int, trim_inf=True):
         r"""Construct Handy transformation.
@@ -1662,10 +1811,29 @@ class HandyRTransform(BaseTransform):
 
 
 class HandyModRTransform(BaseTransform):
-    r"""Modified Handy Transformation class."""
+    r"""Modified Handy Transformation class from :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`.
+
+    This transformation is given by
+
+    .. math::
+        r(x) = \frac{(1+x)^m (r_{max} - r_{min})}
+                { 2^m (1 - 2^m + r_{max} - r_{min})
+                  - (1 + x)^m (r_{max} - r_{min} - 2^m )} + r_{min},
+
+    where :math:`m > 0`.
+
+    The inverse transformation is given by
+
+    .. math::
+        x(r) =  2 \sqrt[m]{
+                \frac{(r - r_{min})(r_{max} - r_{min} - 2^m + 1)}
+                {(r - r_{min})(r_{max} - r_{min} - 2^m) + r_{max} - r_{min}}
+                } - 1.
+
+    """
 
     def __init__(self, rmin: float, rmax: float, m: int, trim_inf=True):
-        r"""Construct a modified Handy transform [-1,1] -> [rmin,rmax].
+        r"""Construct a modified Handy transform from :math:`[-1, 1]` to :math:`[r_{min}, r_{max}]`.
 
         Parameters
         ----------
@@ -1710,7 +1878,7 @@ class HandyModRTransform(BaseTransform):
         return self._m
 
     def transform(self, x: np.ndarray):
-        r"""Transform given array [-1,1] to radial array [rmin,rmax].
+        r"""Transform given array :math:`[-1,1]` to radial array :math:`[r_{min},r_{max}]`.
 
         .. math::
             r_i = \frac{(1+x_i)^m (r_{max} - r_{min})}

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -25,8 +25,8 @@ from unittest import TestCase
 from grid.atomgrid import AtomGrid
 from grid.basegrid import Grid, OneDGrid
 from grid.lebedev import AngularGrid, LEBEDEV_DEGREES
-from grid.onedgrid import GaussLegendre, HortonLinear
-from grid.rtransform import BeckeTF, IdentityRTransform, PowerRTransform
+from grid.onedgrid import GaussLegendre, UniformInteger
+from grid.rtransform import BeckeRTransform, IdentityRTransform, PowerRTransform
 
 import numpy as np
 from numpy.testing import (
@@ -78,7 +78,7 @@ class TestAtomGrid(TestCase):
     def test_from_predefined(self):
         """Test grid construction with predefined grid."""
         # test coarse grid
-        pts = HortonLinear(20)
+        pts = UniformInteger(20)
         tf = PowerRTransform(7.0879993828935345e-06, 16.05937640019924)
         rad_grid = tf.transform_1d_grid(pts)
         atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="coarse")
@@ -90,7 +90,7 @@ class TestAtomGrid(TestCase):
         )
 
         # test medium grid
-        pts = HortonLinear(24)
+        pts = UniformInteger(24)
         tf = PowerRTransform(3.69705074304963e-06, 19.279558946793685)
         rad_grid = tf.transform_1d_grid(pts)
         atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="medium")
@@ -101,7 +101,7 @@ class TestAtomGrid(TestCase):
             5.56834559,
         )
         # test fine grid
-        pts = HortonLinear(34)
+        pts = UniformInteger(34)
         tf = PowerRTransform(2.577533167224667e-07, 16.276983371222354)
         rad_grid = tf.transform_1d_grid(pts)
         atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="fine")
@@ -112,7 +112,7 @@ class TestAtomGrid(TestCase):
             5.56832800,
         )
         # test veryfine grid
-        pts = HortonLinear(41)
+        pts = UniformInteger(41)
         tf = PowerRTransform(1.1774580743206259e-07, 20.140888089596444)
         rad_grid = tf.transform_1d_grid(pts)
         atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="veryfine")
@@ -123,7 +123,7 @@ class TestAtomGrid(TestCase):
             5.56832800,
         )
         # test ultrafine grid
-        pts = HortonLinear(49)
+        pts = UniformInteger(49)
         tf = PowerRTransform(4.883104847991021e-08, 21.05456999309752)
         rad_grid = tf.transform_1d_grid(pts)
         atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="ultrafine")
@@ -134,7 +134,7 @@ class TestAtomGrid(TestCase):
             5.56832800,
         )
         # test insane grid
-        pts = HortonLinear(59)
+        pts = UniformInteger(59)
         tf = PowerRTransform(1.9221827244049134e-08, 21.413278983919113)
         rad_grid = tf.transform_1d_grid(pts)
         atgrid = AtomGrid.from_preset(rad_grid, atnum=1, preset="insane")
@@ -321,7 +321,7 @@ class TestAtomGrid(TestCase):
     def test_spherical_complete(self):
         """Test atomitc grid consistence for spherical integral."""
         num_pts = len(LEBEDEV_DEGREES)
-        pts = HortonLinear(num_pts)
+        pts = UniformInteger(num_pts)
         for _ in range(10):
             start = np.random.rand() * 1e-5
             end = np.random.rand() * 10 + 10
@@ -420,7 +420,7 @@ class TestAtomGrid(TestCase):
     def test_cubicspline_and_interp_gauss(self):
         """Test cubicspline interpolation values."""
         oned = GaussLegendre(30)
-        btf = BeckeTF(0.0001, 1.5)
+        btf = BeckeRTransform(0.0001, 1.5)
         rad = btf.transform_1d_grid(oned)
         atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         value_array = self.helper_func_gauss(atgrid.points)
@@ -575,7 +575,7 @@ class TestAtomGrid(TestCase):
             AtomGrid._generate_real_sph_harm(-1, np.random.rand(10), np.random.rand(10))
         with self.assertRaises(ValueError):
             oned = GaussLegendre(30)
-            btf = BeckeTF(0.0001, 1.5)
+            btf = BeckeRTransform(0.0001, 1.5)
             rad = btf.transform_1d_grid(oned)
             atgrid = AtomGrid.from_preset(rad, atnum=1, preset="fine")
             atgrid.fit_values(np.random.rand(100))

--- a/src/grid/tests/test_interpolate.py
+++ b/src/grid/tests/test_interpolate.py
@@ -33,7 +33,7 @@ from grid.interpolate import (
 )
 from grid.lebedev import AngularGrid
 from grid.onedgrid import GaussLegendre
-from grid.rtransform import BeckeTF, IdentityRTransform
+from grid.rtransform import BeckeRTransform, IdentityRTransform
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal, assert_array_equal
@@ -156,7 +156,7 @@ class TestInterpolate(TestCase):
     def test_cubicspline_and_interp_gauss(self):
         """Test cubicspline interpolation values."""
         oned = GaussLegendre(30)
-        btf = BeckeTF(0.0001, 1.5)
+        btf = BeckeRTransform(0.0001, 1.5)
         rad = btf.transform_1d_grid(oned)
         atgrid = AtomGrid.from_pruned(rad, 1, sectors_r=[], sectors_degree=[7])
         value_array = self.helper_func_gauss(atgrid.points)

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -25,7 +25,7 @@ from grid.basegrid import LocalGrid
 from grid.becke import BeckeWeights
 from grid.hirshfeld import HirshfeldWeights
 from grid.molgrid import MolGrid
-from grid.onedgrid import GaussLaguerre, HortonLinear
+from grid.onedgrid import GaussLaguerre, UniformInteger
 from grid.rtransform import ExpRTransform
 
 # from importlib_resources import path
@@ -38,7 +38,7 @@ class TestMolGrid(TestCase):
 
     def setUp(self):
         """Set up radial grid for integral tests."""
-        pts = HortonLinear(100)
+        pts = UniformInteger(100)
         tf = ExpRTransform(1e-5, 2e1)
         self.rgrid = tf.transform_1d_grid(pts)
 
@@ -46,7 +46,7 @@ class TestMolGrid(TestCase):
         """Test molecular integral in H atom."""
         # numbers = np.array([1], int)
         coordinates = np.array([0.0, 0.0, -0.5], float)
-        # rgrid = BeckeTF.transform_grid(oned, 0.001, 0.5)[0]
+        # rgrid = BeckeRTransform.transform_grid(oned, 0.001, 0.5)[0]
         # rtf = ExpRTransform(1e-3, 1e1, 100)
         # rgrid = RadialGrid(rtf)
         atg1 = AtomGrid.from_pruned(
@@ -66,7 +66,7 @@ class TestMolGrid(TestCase):
 
     def test_make_grid_integral(self):
         """Test molecular make_grid works as designed."""
-        pts = HortonLinear(70)
+        pts = UniformInteger(70)
         tf = ExpRTransform(1e-5, 2e1)
         rgrid = tf.transform_1d_grid(pts)
         numbers = np.array([1, 1])
@@ -507,7 +507,7 @@ class TestMolGrid(TestCase):
             molg.get_atomic_grid(-5)
 
         # test make_grid error
-        pts = HortonLinear(70)
+        pts = UniformInteger(70)
         tf = ExpRTransform(1e-5, 2e1)
         rgrid = tf.transform_1d_grid(pts)
         numbers = np.array([1, 1])
@@ -616,7 +616,7 @@ class TestMolGrid(TestCase):
 
     def test_integrate_hirshfeld_weights_single_1s(self):
         """Test molecular integral in H atom with Hirshfeld weights."""
-        pts = HortonLinear(100)
+        pts = UniformInteger(100)
         tf = ExpRTransform(1e-5, 2e1)
         rgrid = tf.transform_1d_grid(pts)
         coordinates = np.array([0.0, 0.0, -0.5])

--- a/src/grid/tests/test_ode.py
+++ b/src/grid/tests/test_ode.py
@@ -29,7 +29,7 @@ from grid.rtransform import (
     BeckeRTransform,
     IdentityRTransform,
     InverseRTransform,
-    LinearFiniteTF,
+    LinearFiniteRTransform,
 )
 
 import numpy as np
@@ -44,7 +44,7 @@ class TestODE(TestCase):
     def test_transform_coeff_with_x_and_r(self):
         """Test coefficient transform between x and r."""
         coeff = np.array([2, 3, 4])
-        ltf = LinearFiniteTF(1, 10)  # (-1, 1) -> (r0, rmax)
+        ltf = LinearFiniteRTransform(1, 10)  # (-1, 1) -> (r0, rmax)
         inv_tf = InverseRTransform(ltf)  # (r0, rmax) -> (-1, 1)
         x = np.linspace(-1, 1, 20)
         r = ltf.transform(x)
@@ -71,7 +71,7 @@ class TestODE(TestCase):
     def test_linear_transform_coeff(self):
         """Test coefficient with linear transformation."""
         x = GaussLaguerre(10).points
-        ltf = LinearFiniteTF(1, 10)
+        ltf = LinearFiniteRTransform(1, 10)
         inv_ltf = InverseRTransform(ltf)
         derivs_fun = [inv_ltf.deriv, inv_ltf.deriv2, inv_ltf.deriv3]
         coeff = np.array([2, 3, 4])

--- a/src/grid/tests/test_onedgrid.py
+++ b/src/grid/tests/test_onedgrid.py
@@ -31,7 +31,6 @@ from grid.onedgrid import (
     GaussChebyshevType2,
     GaussLaguerre,
     GaussLegendre,
-    UniformInteger,
     MidPoint,
     RectangleRuleSine,
     RectangleRuleSineEndPoints,
@@ -44,6 +43,7 @@ from grid.onedgrid import (
     TrefethenStripCC,
     TrefethenStripGC2,
     TrefethenStripGeneral,
+    UniformInteger,
     _derg2,
     _derg3,
     _dergstrip,
@@ -171,7 +171,7 @@ class TestOneDGrid(TestCase):
         index_m = np.arange(9) + 1
 
         weights = (
-            (2 / (10 * np.pi ** 2))
+            (2 / (10 * np.pi**2))
             * np.sin(10 * np.pi * points)
             * np.sin(10 * np.pi / 2) ** 2
         )
@@ -253,13 +253,13 @@ class TestOneDGrid(TestCase):
     def helper_gaussian(x):
         """Compute gauss function for integral between [-1, 1]."""
         # integrate (exp(-x^2)) x=[-1, 1], result = 1.49365
-        return np.exp(-(x ** 2))
+        return np.exp(-(x**2))
 
     @staticmethod
     def helper_quadratic(x):
         """Compute quadratic function for integral between [-1, 1]."""
         # integrate (-x^2 + 1) x=[-1, 1], result = 1.33333
-        return -(x ** 2) + 1
+        return -(x**2) + 1
 
     def test_oned_integral(self):
         """A simple integral tests for basic oned grid."""
@@ -382,7 +382,7 @@ class TestOneDGrid(TestCase):
             serie = 0
 
             for m in range(1, nsum):
-                serie += np.cos(2 * m * theta[k]) / (4 * m ** 2 - 1)
+                serie += np.cos(2 * m * theta[k]) / (4 * m**2 - 1)
 
             serie = 1 - 2 * serie
 

--- a/src/grid/tests/test_onedgrid.py
+++ b/src/grid/tests/test_onedgrid.py
@@ -31,7 +31,7 @@ from grid.onedgrid import (
     GaussChebyshevType2,
     GaussLaguerre,
     GaussLegendre,
-    HortonLinear,
+    UniformInteger,
     MidPoint,
     RectangleRuleSine,
     RectangleRuleSineEndPoints,
@@ -90,7 +90,7 @@ class TestOneDGrid(TestCase):
 
     def test_horton_linear(self):
         """Test horton linear grids."""
-        grid = HortonLinear(10)
+        grid = UniformInteger(10)
         assert_allclose(grid.points, np.arange(10))
         assert_allclose(grid.weights, np.ones(10))
 
@@ -221,7 +221,7 @@ class TestOneDGrid(TestCase):
         with self.assertRaises(ValueError):
             GaussChebyshev(-10)
         with self.assertRaises(ValueError):
-            HortonLinear(-10)
+            UniformInteger(-10)
         with self.assertRaises(ValueError):
             TanhSinh(10, 1)
         with self.assertRaises(ValueError):

--- a/src/grid/tests/test_onedgrid.py
+++ b/src/grid/tests/test_onedgrid.py
@@ -435,8 +435,8 @@ class TestOneDGrid(TestCase):
         assert_allclose(d3ref, newd3)
 
     def test_TrefethenCC_d2(self):
-        """Test for Trefethen - Sausage Clenshaw Curtis and parameter d=2."""
-        grid = TrefethenCC(10, 2)
+        """Test for Trefethen - Sausage Clenshaw Curtis and parameter d=5."""
+        grid = TrefethenCC(10, 5)
 
         tmp = ClenshawCurtis(10)
 
@@ -447,8 +447,8 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.weights, new_weights)
 
     def test_TrefethenCC_d3(self):
-        """Test for Trefethen - Sausage Clenshaw Curtis and parameter d=3."""
-        grid = TrefethenCC(10, 3)
+        """Test for Trefethen - Sausage Clenshaw Curtis and parameter d=9."""
+        grid = TrefethenCC(10, 9)
 
         tmp = ClenshawCurtis(10)
 
@@ -459,8 +459,8 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.weights, new_weights)
 
     def test_TrefethenCC_d0(self):
-        """Test for Trefethen - Sausage Clenshaw Curtis and parameter d=0."""
-        grid = TrefethenCC(10, 0)
+        """Test for Trefethen - Sausage Clenshaw Curtis and parameter d=1."""
+        grid = TrefethenCC(10, 1)
 
         tmp = ClenshawCurtis(10)
 
@@ -468,8 +468,8 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.weights, tmp.weights)
 
     def test_TrefethenGC2_d2(self):
-        """Test for Trefethen - Sausage GaussChebyshev2 and parameter d=2."""
-        grid = TrefethenGC2(10, 2)
+        """Test for Trefethen - Sausage GaussChebyshev2 and parameter d=5."""
+        grid = TrefethenGC2(10, 5)
 
         tmp = GaussChebyshevType2(10)
 
@@ -480,8 +480,8 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.weights, new_weights)
 
     def test_TrefethenGC2_d3(self):
-        """Test for Trefethen - Sausage GaussChebyshev2 and parameter d=3."""
-        grid = TrefethenGC2(10, 3)
+        """Test for Trefethen - Sausage GaussChebyshev2 and parameter d=9."""
+        grid = TrefethenGC2(10, 9)
 
         tmp = GaussChebyshevType2(10)
 
@@ -492,8 +492,8 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.weights, new_weights)
 
     def test_TrefethenGC2_d0(self):
-        """Test for Trefethen - Sausage GaussChebyshev2 and parameter d=0."""
-        grid = TrefethenGC2(10, 0)
+        """Test for Trefethen - Sausage GaussChebyshev2 and parameter d=1."""
+        grid = TrefethenGC2(10, 1)
 
         tmp = GaussChebyshevType2(10)
 
@@ -501,25 +501,25 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.weights, tmp.weights)
 
     def test_TrefethenGeneral_d2(self):
-        """Test for Trefethen - Sausage General and parameter d=2."""
-        grid = TrefethenGeneral(10, ClenshawCurtis, 2)
-        new = TrefethenCC(10, 2)
+        """Test for Trefethen - Sausage General and parameter d=5."""
+        grid = TrefethenGeneral(10, ClenshawCurtis, 5)
+        new = TrefethenCC(10, 5)
 
         assert_allclose(grid.points, new.points)
         assert_allclose(grid.weights, new.weights)
 
     def test_TrefethenGeneral_d3(self):
-        """Test for Trefethen - Sausage General and parameter d=2."""
-        grid = TrefethenGeneral(10, ClenshawCurtis, 3)
-        new = TrefethenCC(10, 3)
+        """Test for Trefethen - Sausage General and parameter d=9."""
+        grid = TrefethenGeneral(10, ClenshawCurtis, 9)
+        new = TrefethenCC(10, 9)
 
         assert_allclose(grid.points, new.points)
         assert_allclose(grid.weights, new.weights)
 
     def test_TrefethenGeneral_d0(self):
-        """Test for Trefethen - Sausage General and parameter d=0."""
-        grid = TrefethenGeneral(10, ClenshawCurtis, 0)
-        new = TrefethenCC(10, 0)
+        """Test for Trefethen - Sausage General and parameter d=1."""
+        grid = TrefethenGeneral(10, ClenshawCurtis, 1)
+        new = TrefethenCC(10, 1)
 
         assert_allclose(grid.points, new.points)
         assert_allclose(grid.weights, new.weights)
@@ -537,7 +537,6 @@ class TestOneDGrid(TestCase):
     def test_TrefethenStripCC(self):
         """Test for Trefethen - Strip Clenshaw Curtis."""
         grid = TrefethenStripCC(10, 1.1)
-
         tmp = ClenshawCurtis(10)
 
         new_points = _gstrip(1.1, tmp.points)

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -5,7 +5,7 @@ from grid.atomgrid import AtomGrid
 from grid.interpolate import interpolate, spline_with_atomic_grid
 from grid.onedgrid import GaussChebyshev
 from grid.poisson import Poisson
-from grid.rtransform import BeckeTF, InverseTF
+from grid.rtransform import BeckeRTransform, InverseRTransform
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
@@ -23,7 +23,7 @@ class TestPoisson(TestCase):
     def test_poisson_proj(self):
         """Test the project function."""
         oned = GaussChebyshev(30)
-        btf = BeckeTF(0.0001, 1.5)
+        btf = BeckeRTransform(0.0001, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
         atgrid = AtomGrid(rad, degrees=[l_max])
@@ -65,7 +65,7 @@ class TestPoisson(TestCase):
         """Test the poisson solve function."""
         oned = GaussChebyshev(30)
         oned = GaussChebyshev(50)
-        btf = BeckeTF(1e-7, 1.5)
+        btf = BeckeRTransform(1e-7, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
         atgrid = AtomGrid(rad, degrees=[l_max])
@@ -96,7 +96,7 @@ class TestPoisson(TestCase):
             ref_v = gauss(r) * np.sqrt(4 * np.pi)
             # 0.28209479 is the value in spherical harmonic Z_0_0
             assert_allclose(interp_v, ref_v, atol=1e-3)
-        ibtf = InverseTF(btf)
+        ibtf = InverseRTransform(btf)
         linsp = np.linspace(-1, 0.99, 50)
         bound = p_0 * np.sqrt(4 * np.pi)
         res_bv = Poisson.solve_poisson_bv(spls_mt[0, 0], linsp, bound, tfm=ibtf)
@@ -143,7 +143,7 @@ class TestPoisson(TestCase):
     def test_poisson_solve_mtr_cmpl(self):
         """Test solve poisson equation and interpolate the result."""
         oned = GaussChebyshev(50)
-        btf = BeckeTF(1e-7, 1.5)
+        btf = BeckeRTransform(1e-7, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
         atgrid = AtomGrid(rad, degrees=[l_max])
@@ -161,7 +161,7 @@ class TestPoisson(TestCase):
             atgrid.weights,
             atgrid.indices,
         )
-        ibtf = InverseTF(btf)
+        ibtf = InverseRTransform(btf)
         linsp = np.linspace(-1, 0.99, 50)
         bound = p_0 * np.sqrt(4 * np.pi)
         pois_mtr = Poisson.solve_poisson(spls_mt, linsp, bound, tfm=ibtf)
@@ -201,7 +201,7 @@ class TestPoisson(TestCase):
     def test_raises_errors(self):
         """Test proper error raises."""
         oned = GaussChebyshev(50)
-        btf = BeckeTF(1e-7, 1.5)
+        btf = BeckeRTransform(1e-7, 1.5)
         rad = btf.transform_1d_grid(oned)
         l_max = 7
         atgrid = AtomGrid(rad, degrees=[l_max])

--- a/src/grid/tests/test_radial.py
+++ b/src/grid/tests/test_radial.py
@@ -20,7 +20,7 @@
 """Radial grid test."""
 
 from grid.basegrid import OneDGrid
-from grid.onedgrid import HortonLinear
+from grid.onedgrid import UniformInteger
 from grid.rtransform import ExpRTransform, PowerRTransform
 
 import numpy as np
@@ -29,7 +29,7 @@ from numpy.testing import assert_almost_equal
 
 def test_basics1():
     """Test basic radial grid transform properties."""
-    oned = HortonLinear(4)
+    oned = UniformInteger(4)
     rtf = ExpRTransform(0.1, 1e1)
     grid = rtf.transform_1d_grid(oned)
     assert isinstance(grid, OneDGrid)
@@ -44,7 +44,7 @@ def test_basics1():
 
 def test_basics2():
     """Test basic radial grid transform properties for bigger grid."""
-    oned = HortonLinear(100)
+    oned = UniformInteger(100)
     rtf = ExpRTransform(1e-3, 1e1)
     grid = rtf.transform_1d_grid(oned)
     assert isinstance(grid, OneDGrid)
@@ -59,7 +59,7 @@ def test_basics2():
 
 def test_integrate_gauss():
     """Test radial grid integral."""
-    oned = HortonLinear(100)
+    oned = UniformInteger(100)
     rtf = PowerRTransform(0.0005, 1e1)
     grid = rtf.transform_1d_grid(oned)
     assert isinstance(grid, OneDGrid)

--- a/src/grid/tests/test_rtransform.py
+++ b/src/grid/tests/test_rtransform.py
@@ -26,7 +26,7 @@ from grid.rtransform import (
     ExpRTransform,
     HyperbolicRTransform,
     IdentityRTransform,
-    LinearRTransform,
+    LinearInfiniteRTransform,
     PowerRTransform,
 )
 
@@ -128,7 +128,7 @@ class TestRTransform(TestCase):
     def test_linear_basics(self):
         """Test linear tf."""
         gd = np.ones(100) * 0
-        rtf = LinearRTransform(-0.7, 0.8)
+        rtf = LinearInfiniteRTransform(-0.7, 0.8)
         assert abs(rtf.transform(gd)[0] - -0.7) < 1e-15
         gd = np.ones(100) * 99
         assert abs(rtf.transform(gd)[0] - 0.8) < 1e-10
@@ -178,7 +178,7 @@ class TestRTransform(TestCase):
 
     def test_linear_properties(self):
         """Test linear tf properties."""
-        rtf = LinearRTransform(-0.7, 0.8)
+        rtf = LinearInfiniteRTransform(-0.7, 0.8)
         assert rtf.rmin == -0.7
         assert rtf.rmax == 0.8
         # assert rtf.npoint == 100
@@ -216,7 +216,7 @@ class TestRTransform(TestCase):
             tf = IdentityRTransform()
             tf.transform_1d_grid(rad)
         with self.assertRaises(ValueError):
-            tf = LinearRTransform(0.1, 1.5)
+            tf = LinearInfiniteRTransform(0.1, 1.5)
             tf.transform_1d_grid(rad)
         with self.assertRaises(ValueError):
             tf = ExpRTransform(0.1, 1e1)
@@ -231,7 +231,7 @@ class TestRTransform(TestCase):
     def test_linear_bounds(self):
         """Test linear tf raise errors."""
         with self.assertRaises(ValueError):
-            LinearRTransform(1.1, 0.9)
+            LinearInfiniteRTransform(1.1, 0.9)
 
     def test_exp_bounds(self):
         """Test exponential tf raise errors."""
@@ -305,7 +305,7 @@ def test_identiy_string():
 
 
 def test_linear_string():
-    rtf1 = LinearRTransform(np.random.uniform(1e-5, 5e-5), np.random.uniform(1, 5), 88)
+    rtf1 = LinearInfiniteRTransform(np.random.uniform(1e-5, 5e-5), np.random.uniform(1, 5), 88)
     s = rtf1.to_string()
     rtf2 = RTransform.from_string(s)
     assert rtf1.rmin == rtf2.rmin
@@ -314,11 +314,11 @@ def test_linear_string():
     assert rtf1.alpha == rtf2.alpha
 
     with assert_raises(ValueError):
-        RTransform.from_string("LinearRTransform A 5")
+        RTransform.from_string("LinearInfiniteRTransform A 5")
     with assert_raises(ValueError):
-        RTransform.from_string("LinearRTransform A 5 .1")
+        RTransform.from_string("LinearInfiniteRTransform A 5 .1")
 
-    rtf3 = RTransform.from_string("LinearRTransform -1.0 12.15643216847 77")
+    rtf3 = RTransform.from_string("LinearInfiniteRTransform -1.0 12.15643216847 77")
     assert rtf3.rmin == -1.0
     assert rtf3.rmax == 12.15643216847
     assert rtf3.npoint == 77

--- a/src/grid/tests/test_transform.py
+++ b/src/grid/tests/test_transform.py
@@ -29,7 +29,7 @@ from grid.rtransform import (
     HandyRTransform,
     InverseRTransform,
     KnowlesRTransform,
-    LinearFiniteTF,
+    LinearFiniteRTransform,
     MultiExpRTransform,
 )
 
@@ -200,17 +200,17 @@ class TestTransform(TestCase):
 
     def test_linear_transform(self):
         """Test linear transformation."""
-        ltf = LinearFiniteTF(0.1, 10)
+        ltf = LinearFiniteRTransform(0.1, 10)
         self._transform_and_inverse(-1, 1, ltf)
 
     def test_linear_finite_diff(self):
         """Test finite diff for linear derivs."""
-        ltf = LinearFiniteTF(0.1, 10)
+        ltf = LinearFiniteRTransform(0.1, 10)
         self._deriv_finite_diff(-1, 1, ltf)
 
     def test_linear_inverse(self):
         """Test inverse transform and derivs function."""
-        ltf = LinearFiniteTF(0.1, 10)
+        ltf = LinearFiniteRTransform(0.1, 10)
         iltf = InverseRTransform(ltf)
         # transform & inverse
         self._transform_and_inverse(0, 20, iltf)
@@ -393,7 +393,7 @@ class TestTransform(TestCase):
             tf = KnowlesRTransform(0.1, 1.2, 2)
             tf.transform_1d_grid(rad)
         with self.assertRaises(ValueError):
-            tf = LinearFiniteTF(0.1, 10)
+            tf = LinearFiniteRTransform(0.1, 10)
             tf.transform_1d_grid(rad)
         with self.assertRaises(ValueError):
             tf = MultiExpRTransform(0.1, 1.2)


### PR DESCRIPTION
This pull-request refactors (mostly documentation fixes) for onedgrid.py and rtransform.py.  

Key changes are:
- Added type hinting
- Changed the documentation in both files by fixing typos, adding equations, some references.
- Made it more explicit as to which intervals it's being mapped to in the documentation.
- Fixed flake8 and black issues
- cfcffc214e528b22ef7331ad9b541572c9c9a875 For Trefethen transformation in onedgrid.py, I made it more explicit that the d parameter is the degree of the Taylor polynomial of sin^{-1} and changed it so that it matches the equations, i.e. d=1 is identity, d=3 is the third degree etc. See the paper in [dropbox](https://drive.google.com/drive/folders/1ZBL50iFLchFspMYMcaNon_5seCrWAYua).
- da8509e685df865a5a0e6a0383dc1a39c7b63f8e Changed the naming of TF to RTransform to make it consistent across all classes in rtransform.py
- I changed HortonLinear to UniformInteger, because this generates an equally-spaced integer grid from 0 to N-1 with weights equal to one.  This plays a huge role below.
- The problem in issue #125, is that the MultiExponential transform transform points to `f(x) = -R log ((x + 1) / 2)` and thus it swaps the endpoints `f(1) = 0` and `f(-1)=infty`.  Hence, when the base class OneDGrid transforms, it sees that the bounds [infity, 0] is invalid because it isn't ordered correctly.  I fixed this in 4b17f0a25bd5171c5baeaa27b0041a0d578f8f41 by always sorting the domain to get [0, infty].

The biggest issue I have is the radial transformations (LinearRTransform, ExpRTransform, PowerRTransform, HyperbolicRTransform) which were obtained from [Horton/grid.py]() and how the documentation in python grid isn't correct as to what the domain/codomain are and they seem to be very specific to HortonGrid/UniformInteger class.   For example, for LinearRTransform it transforms according to `r(x) = rmin + x*(rmax - rmin)/(npoint - 1)`, where npoint is the number of points, rmin is the minimum of grid and rmax is maximum of grid.    

The docs claim that it maps to `[r_min, r_{max}]` but this is only true if you're using HortonLinear/UniformInteger grid.  This is also a problem in ExpRTransform and PowerRTransform, where it only maps to `[r_{min}, r_{max}]` only if you're using HortonLinear grid.  One easy way of fixing this, is to replace `npoint - 1` to taking the maximum over all grid points i.e. `np.max(grid.points)`, this will hold true for any grid.

For HyperbolicRTransform, the mapping `r(x) = ax/ (1 - bx)` where a, b are positive scalars. It doesn't map to [0, \infty) but rather it can map everywhere.  Additionally, there is the constraint `b(npoints - 1) >= 1` that isn't explicit in the docs, I'm assuming it is also specific to HortonGrid where it centers the singularity at `npoints - 1` and you only want the positive points on the left-side of singularity, see [desmos/grapher](https://www.desmos.com/calculator/ik0eevj29b), where `N=npoints`.

References
----------------
List of radial transforms:  https://www.pamoc.it/tpc_num_int.html#VOL-B