### PR TITLE
Improve documentation in lebedev.py and interpolate.py

### DIFF
--- a/src/grid/interpolate.py
+++ b/src/grid/interpolate.py
@@ -70,39 +70,49 @@ def generate_real_sph_harms(l_max: int, theta: np.ndarray, phi: np.ndarray):
     return np.nan_to_num(_convert_ylm_to_zlm(sph_h))
 
 
-def generate_sph_harms(l_max, theta, phi):
-    """Generate complex spherical harmonics.
+def generate_sph_harms(l_max: int, theta: np.ndarray, phi: np.ndarray):
+    r"""Generate complex spherical harmonics up to degree :math:`l` and for all orders :math:`m`.
 
     Parameters
     ----------
     l_max : int
-        largest angular degree
-    theta : np.ndarray(N,)
-        Azimuthal angles
-    phi : np.ndarray(N,)
-        Polar angles
+        Largest angular degree of the spherical harmonics.
+    theta : ndarray(N,)
+        Azimuthal angles.
+    phi : ndarray(N,)
+        Polar angles.
 
     Returns
     -------
-    np.ndarray(l_max * 2 + 1, l_max + 1, N)
-        value of angular grid in each m, n spherical harmonics
+    ndarray(l_max * 2 + 1, l_max + 1, N)
+        Value of complex spherical harmonics of all orders :math:`m`,and degree
+        :math:`l` spherical harmonics. First coordinate is the order :math:`m`, the second is
+        the degree :math:`l`, and the third coordinate specifies which point on the unit sphere.
+        The order :math:`m` is ordered according to the following:
+        :math:`[0, 1, \cdots, l_max, -l_max, \cdots, -1]`.
+
     """
+    # The "order" in the order m was chosen so output[m, l, :] works when -l <= m <= l.
     # theta azimuthal, phi polar
     l, m = _generate_sph_paras(l_max)
     return sph_harm(m[:, None, None], l[None, :, None], theta, phi)
 
 
-def _generate_sph_paras(l_max):
-    """Generate proper l and m list for l.
+def _generate_sph_paras(l_max: int):
+    r"""Return all degrees up to l_max and list of all orders m for l_max.
 
     Parameters
     ----------
     l_max : int
+        Largest angular degree of the spherical harmonics.
 
     Returns
     -------
-    list
-        l = [0, 1, 2.., l_max], m = [0, 1, ... l_max, -l_max, ..., -1]
+    (list, list)
+        Returns two list, the first is the all the orders from l=0 to l_max.
+        The second is the order :math:`m` when `l=l_{max}`, ordered as follows
+        :math:`[0, 1, \cdots, l_max, -l_max, \cdots, -1]`.
+
     """
     l_list = np.arange(l_max + 1)
     m_list_p = np.arange(l_max + 1)
@@ -112,7 +122,7 @@ def _generate_sph_paras(l_max):
 
 
 def _convert_ylm_to_zlm(sp_harm_arrs):
-    """Converge complex spherical into real spherical harmonics."""
+    """Convert complex spherical into real spherical harmonics."""
     ms, ls, arrs = sp_harm_arrs.shape  # got list of Ls, and Ms
     # ls = l_max + 1
     # ms = 2 * l_max + 1

--- a/src/grid/interpolate.py
+++ b/src/grid/interpolate.py
@@ -17,9 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-"""Interpolation module for evaluating function value at any point."""
+"""Interpolating real-valued functions wrt radial coordinate in spherical coordinates."""
 
 import warnings
+
+from grid.atomgrid import AtomGrid
+from grid.basegrid import OneDGrid
 
 import numpy as np
 
@@ -27,23 +30,42 @@ from scipy.interpolate import CubicSpline
 from scipy.special import sph_harm
 
 
-def generate_real_sph_harms(l_max, theta, phi):
-    """Generate real spherical harmonics.
+def generate_real_sph_harms(l_max: int, theta: np.ndarray, phi: np.ndarray):
+    r"""Generate real spherical harmonics up to degree :math:`l` and for all orders :math:`m`.
+
+    The real spherical harmonics are defined as a function
+    :math:`Y_{lm} : L^2(S^2) \rightarrow \mathbb{R}` such that
+
+    .. math::
+        Y_{lm} = \begin{cases}
+            \frac{i}{\sqrt{2}} (Y^m_l - (-1)^m Y_l^{-m} & \text{if } < m < 0 \\
+            Y_l^0 & \text{if } m = 0 \\
+            \frac{1}{\sqrt{2}} (Y^{-|m|}_{l} + (-1)^m Y_l^m) & \text{if } m > 0
+        \end{cases},
+
+    where :math:`l \in \mathbb{Z}`, :math:`m \in \{-l_{max}, \cdots, l_{max} \}` and
+    :math:`Y^m_l` is the complex spherical harmonic.
 
     Parameters
     ----------
     l_max : int
-        largest angular degree
-    theta : np.ndarray(N,)
-        Azimuthal angles
-    phi : np.ndarray(N,)
-        Polar angles
+        Largest angular degree of the spherical harmonics.
+    theta : ndarray(N,)
+        Azimuthal angles that are being evaluated on.
+    phi : ndarray(N,)
+        Polar angles that are being evaluated on.
 
     Returns
     -------
-    np.ndarray(l_max * 2 + 1, l_max + 1, N)
-        value of angular grid in each m, n spherical harmonics
+    ndarray(l_max * 2 + 1, l_max + 1, N)
+        Value of real spherical harmonics of all orders :math:`m`,and degree
+        :math:`l` spherical harmonics. First coordinate is the order :math:`m`, the second is
+        the degree :math:`l`, and the third coordinate specifies which point on the unit sphere.
+        The order :math:`m` is ordered according to the following:
+        :math:`[0, 1, \cdots, l_max, -l_max, \cdots, -1]`.
+
     """
+    # The "order" in the order m was chosen so that sph_h[m, l, :] works when -l <= m <= l.
     sph_h = generate_sph_harms(l_max, theta, phi)
     return np.nan_to_num(_convert_ylm_to_zlm(sph_h))
 

--- a/src/grid/lebedev.py
+++ b/src/grid/lebedev.py
@@ -17,9 +17,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-"""Lebedev Angular Grid Module.
+"""
+Lebedev angular grid module for constructing integration grids on the unit sphere.
 
-TODO: Describe how the stored points & weights were calculated.
+The Lebedev grid points here were obtained and calculated from the theochem/HORTON package.
+Their calculations were based on F77 translation by Dr. Christoph van Wuellen
+and these are the comments from that translation.
+
+This subroutine is part of a set of subroutines that generate
+Lebedev grids [1-6] for integration on a sphere. The original
+C-code [1] was kindly provided by Dr. Dmitri N. Laikov and
+translated into fortran by Dr. Christoph van Wuellen.
+This subroutine was translated from C to fortran77 by hand.
+Users of this code are asked to include reference [1] in their
+publications, and in the user- and programmers-manuals
+describing their codes.
+This code was distributed through CCL (http://www.ccl.net/).
+
+References
+----------
+.. [1] V.I. Lebedev, and D.N. Laikov
+   "A quadrature formula for the sphere of the 131st algebraic order of accuracy"
+   Doklady Mathematics, Vol. 59, No. 3, 1999, pp. 477-481.
+.. [2] V.I. Lebedev "A quadrature formula for the sphere of 59th algebraic order of accuracy"
+   Russian Acad. Sci. Dokl. Math., Vol. 50, 1995, pp. 283-286.
+.. [3] V.I. Lebedev, and A.L. Skorokhodov "Quadrature formulas of orders 41, 47, and 53 for
+   the sphere" Russian Acad. Sci. Dokl. Math., Vol. 45, 1992, pp. 587-592.
+.. [4] V.I. Lebedev "Spherical quadrature formulas exact to orders 25-29"
+   Siberian Mathematical Journal, Vol. 18, 1977, pp. 99-107.
+.. [5] V.I. Lebedev "Quadratures on a sphere" Computational Mathematics and Mathematical
+   Physics, Vol. 16, 1976, pp. 10-24.
+.. [6] V.I. Lebedev "Values of the nodes and weights of ninth to seventeenth order Gauss-Markov
+   quadrature formulae invariant under the octahedron group with inversion" Computational
+   Mathematics and Mathematical Physics, Vol. 15, 1975, pp. 44-51.
+
 """
 
 import warnings


### PR DESCRIPTION
This pull request mostly improves the documentation in lebedev.py and interpolate.py modules.

Added couple tests in lebedev (a7b2b36fe97b701b7f9a650f51a3da9576f88673) and interpolate (aabffa92053e4fa15fe3efb262a25b8d6e961c46).  The commit headers should be clear which documentation were being changed.   Black and flake8 problems were fixed and type hinting was added.