### PR TITLE
Refactor ode

### DIFF
--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -17,7 +17,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-"""Generic ode solver module."""
+"""Linear ordinary differential equation solver with boundary conditions.
+
+Solves a linear ordinary differential equation of order :math:`K` of the form
+
+.. math::
+    \sum_{k=0}^{K} a_k(x) \frac{d^k y(x)}{dx^k} = f(x)
+
+with boundary conditions on the two end-points for some unknown function
+:math:`y(x)` with independent variable :math:`x`. Currently only supports :math:`K`-th
+order less than or equal to three.
+
+It also supports the ability to transform the independent variable :math:`x`
+to another domain :math:`g(x)` for some :math:`K`-th differentiable transformation
+:math:`g(x)`.  This is particularly useful to convert infinite domains, e.g.
+:math:`[0, \infty)`, to a finite interval. module.
+"""
 
 from numbers import Number
 from typing import Union
@@ -31,346 +46,327 @@ from scipy.integrate import solve_bvp
 
 from sympy import bell
 
+__all__ = ["solve_ode"]
 
-class ODE:
-    r"""
-    Linear ordinary differential equation solver with boundary conditions.
 
-    Solves a linear ordinary differential equation of order :math:`K` of the form
+def solve_ode(
+    x: np.ndarray,
+    fx: callable,
+    coeffs: Union[list, np.ndarray],
+    bd_cond: list,
+    transform: BaseTransform = None,
+    tol: float = 1e-4,
+    max_nodes: int = 5000,
+    initial_guess_y: np.ndarray = None,
+):
+    r"""Solve a linear ODE with boundary conditions.
 
-    .. math::
-        \sum_{k=0}^{K} a_k(x) \frac{d^k y(x)}{dx^k} = f(x)
+    Parameters
+    ----------
+    x : np.ndarray(N,)
+        Points of the independent variable/domain.
+    fx : callable
+        Right-hand function :math:`f(x)`.
+    coeffs : list[callable or float] or ndarray(K + 1,)
+        Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
+        ordered from 0 to K. Either a list of callable functions :math:`a_k(x)` that depends
+        on :math:`x` or array of constants :math:`\{a_k\}_{k=0}^{K}`.
+    bd_cond : list[list[int, int, float]]
+        Boundary condition specified by list of three entries [i, j, C], where
+        :math:`i \in \{0, 1\}` determines whether the lower or upper bound is being
+        constrained, :math:`j \in \{0, \cdots, K\}` determines which derivative
+        :math:`\frac{d^j y}{dx^j}` is being constrained, and :math:`C`
+        determines the boundary constraint value, i.e. :math:`\frac{d^j y}{dx^j} = C`.
+        If `transform` is given, then the constraint of the derivatives is assumed
+        to be with respect to the new coordinate i.e. :math:`\frac{d^j y}{dr^j} = C`.
+    transform : BaseTransform, optional
+        Transformation from one domain :math:`x` to another :math:`r := g(x)`.
+    tol : float, optional
+        Tolerance of the ODE solver and for the boundary condition residuals.
+        See `scipy.integrate.solve_bvp` for more info.
+    max_nodes : int, optional
+        The maximum number of mesh nodes that determine termination.
+        See `scipy.integrate.solve_bvp` function for more info.
+    initial_guess_y : ndarray, optional
+        Initial guess for :math:`y(x)` at the points `x`. If not provided, then
+        random set of points from 0 to 1 is used.
 
-    with boundary conditions on the two end-points for some unknown function
-    :math:`y(x)` with independent variable :math:`x`. Currently only supports :math:`K`-th
-    order less than or equal to three.
-
-    It also supports the ability to transform the independent variable :math:`x`
-    to another domain :math:`g(x)` for some :math:`K`-th differentiable transformation
-    :math:`g(x)`.  This is particularly useful to convert infinite domains, e.g.
-    :math:`[0, \infty)`, to a finite interval.
+    Returns
+    -------
+    PPoly
+        scipy.interpolate.PPoly instance for interpolating new values
+        and its derivative
 
     """
+    order = len(coeffs) - 1
+    if len(bd_cond) != order:
+        raise NotImplementedError(
+            "Number of boundary condition need to be the same as ODE order."
+            f"Expect: {order}, got: {len(bd_cond)}."
+        )
+    if order > 3:
+        raise NotImplementedError("Only support 3rd order ODE or less.")
 
-    @staticmethod
-    def solve_ode(
-        x: np.ndarray,
-        fx: callable,
-        coeffs: Union[list, np.ndarray],
-        bd_cond: list,
-        transform: BaseTransform = None,
-        tol: float = 1e-4,
-        max_nodes: int = 5000,
-        initial_guess_y: np.ndarray = None,
-    ):
-        r"""Solve a linear ODE with boundary conditions.
-
-        Parameters
-        ----------
-        x : np.ndarray(N,)
-            Points of the independent variable/domain.
-        fx : callable
-            Right-hand function :math:`f(x)`.
-        coeffs : list[callable or float] or ndarray(K + 1,)
-            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
-            ordered from 0 to K. Either a list of callable functions :math:`a_k(x)` that depends
-            on :math:`x` or array of constants :math:`\{a_k\}_{k=0}^{K}`.
-        bd_cond : list[list[int, int, float]]
-            Boundary condition specified by list of three entries [i, j, C], where
-            :math:`i \in \{0, 1\}` determines whether the lower or upper bound is being
-            constrained, :math:`j \in \{0, \cdots, K\}` determines which derivative
-            :math:`\frac{d^j y}{dx^j}` is being constrained, and :math:`C`
-            determines the boundary constraint value, i.e. :math:`\frac{d^j y}{dx^j} = C`.
-            If `transform` is given, then the constraint of the derivatives is assumed
-            to be with respect to the new coordinate i.e. :math:`\frac{d^j y}{dr^j} = C`.
-        transform : BaseTransform, optional
-            Transformation from one domain :math:`x` to another :math:`r := g(x)`.
-        tol : float, optional
-            Tolerance of the ODE solver and for the boundary condition residuals.
-            See `scipy.integrate.solve_bvp` for more info.
-        max_nodes : int, optional
-            The maximum number of mesh nodes that determine termination.
-            See `scipy.integrate.solve_bvp` function for more info.
-        initial_guess_y : ndarray, optional
-            Initial guess for :math:`y(x)` at the points `x`. If not provided, then
-            random set of points from 0 to 1 is used.
-
-        Returns
-        -------
-        PPoly
-            scipy.interpolate.PPoly instance for interpolating new values
-            and its derivative
-
-        """
-        order = len(coeffs) - 1
-        if len(bd_cond) != order:
-            raise NotImplementedError(
-                "Number of boundary condition need to be the same as ODE order."
-                f"Expect: {order}, got: {len(bd_cond)}."
+    # define first order ODE for solver, needs to be in explicit form for scipy solver.
+    def func(x, y):
+        # x has shape (N,) and y has shape (K+1, N), output has shape (K+1, N)
+        if transform:
+            dy_dx = _transform_and_rearrange_to_explicit_ode(
+                x, y, coeffs, transform, fx
             )
-        if order > 3:
-            raise NotImplementedError("Only support 3rd order ODE or less.")
+        else:
+            coeffs_mt = _evaluate_coeffs_on_points(x, coeffs)
+            dy_dx = _rearrange_to_explicit_ode(y, coeffs_mt, fx(x))
+        # (*y[1:, :],) returns a tuple of all rows excluding the first row.
+        #    This is due to conversion to first-order ODE form.
+        return np.vstack((*y[1:, :], dy_dx))
 
-        # define first order ODE for solver, needs to be in explicit form for scipy solver.
-        def func(x, y):
-            # x has shape (N,) and y has shape (K+1, N), output has shape (K+1, N)
-            if transform:
-                dy_dx = ODE._transform_and_rearrange_to_explicit_ode(
-                    x, y, coeffs, transform, fx
-                )
-            else:
-                coeffs_mt = ODE._evaluate_coeffs_on_points(x, coeffs)
-                dy_dx = ODE._rearrange_to_explicit_ode(y, coeffs_mt, fx(x))
-            # (*y[1:, :],) returns a tuple of all rows excluding the first row.
-            #    This is due to conversion to first-order ODE form.
-            return np.vstack((*y[1:, :], dy_dx))
+    # define boundary condition
+    def bc(ya, yb):
+        # a denotes the lower bound, b denotes the upper bound
+        # Input of ya, yb should have shape (K+1,) , output should be shape (K+1,)
+        bonds = [ya, yb]
+        conds = []
+        for i, deriv, value in bd_cond:
+            conds.append(bonds[i][deriv] - value)
+        return np.array(conds)
 
-        # define boundary condition
-        def bc(ya, yb):
-            # a denotes the lower bound, b denotes the upper bound
-            # Input of ya, yb should have shape (K+1,) , output should be shape (K+1,)
-            bonds = [ya, yb]
-            conds = []
-            for i, deriv, value in bd_cond:
-                conds.append(bonds[i][deriv] - value)
-            return np.array(conds)
+    if initial_guess_y is None:
+        initial_guess_y = np.random.rand(order, x.size)
+    res = solve_bvp(func, bc, x, y=initial_guess_y, tol=tol, max_nodes=max_nodes)
+    # raise error if didn't converge
+    if res.status != 0:
+        raise ValueError(
+            f"The ode solver didn't converge, got status: {res.status}"
+        )
+    return res.sol
 
-        if initial_guess_y is None:
-            initial_guess_y = np.random.rand(order, x.size)
-        res = solve_bvp(func, bc, x, y=initial_guess_y, tol=tol, max_nodes=max_nodes)
-        # raise error if didn't converge
-        if res.status != 0:
-            raise ValueError(
-                f"The ode solver didn't converge, got status: {res.status}"
+
+def _transform_ode_from_derivs(
+    coeffs: Union[list, np.ndarray], deriv_transformation: list, r: np.ndarray
+):
+    r"""
+    Transform the coefficients of ODE from one variable to another evaluated on mesh points.
+
+    Given a :math:`K`-th differentiable transformation function :math:`g(r)`
+    and a linear ODE of :math:`K`-th order on independent variable :math:`r`
+
+    .. math::
+        \sum_{k=1}^{K} a_k(r) \frac{d^k y}{d r^k}.
+
+    This transforms it into a new coordinate system :math:`g(r) =: x`
+
+    .. math::
+        \sum_{j=1}^K b_j(x) \frac{d^j y}{d x^j},
+
+    where :math:`b_j(x) = \sum_{k=1}^K a_k(x) B_{k, j}(g(r), g^\prime(r), \cdots,
+    g^{k - j + 1}(r))`.
+
+    Parameters
+    ----------
+    coeffs : list[callable or number] or ndarray
+        Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d r^k}`
+        ordered from 0 to K. Either a list of callable functions :math:`a_k(r)` that depends
+        on :math:`r` or array of constants :math:`\{a_k\}_{k=0}^{K}`.
+    deriv_transformation : list[callable]
+        List of functions for compute transformation derivatives from 1 to :math:`K`.
+    r : ndarray
+        Points from the original domain that is to be transformed.
+
+    Returns
+    -------
+    ndarray((K+1, N))
+        Coefficients :math:`b_j(x)` of the new ODE with respect to variable :math:`x`.
+
+    """
+    # `derivs` has shape (K, N), calculate d^j g/ dr^j
+    derivs = np.array([dev(r) for dev in deriv_transformation], dtype=np.float64)
+    total = len(coeffs)  # Should be K+1, K is the order of the ODE
+    # coeff_a_mtr has shape (K+1, N)
+    coeff_a_mtr = _evaluate_coeffs_on_points(r, coeffs)
+    coeff_b = np.zeros((total, r.size), dtype=float)
+    # The first term doesn't contain a derivative so no transformation is required:
+    coeff_b[0] += coeff_a_mtr[0]
+    # construct 1 - 3 directly with vectorization (faster)
+    if total > 1:
+        coeff_b[1] += coeff_a_mtr[1] * derivs[0]
+    if total > 2:
+        coeff_b[1] += coeff_a_mtr[2] * derivs[1]
+        coeff_b[2] += coeff_a_mtr[2] * derivs[0] ** 2
+    if total > 3:
+        coeff_b[1] += coeff_a_mtr[3] * derivs[2]
+        coeff_b[2] += coeff_a_mtr[3] * 3 * derivs[0] * derivs[1]
+        coeff_b[3] += coeff_a_mtr[3] * derivs[0] ** 3
+
+    # construct 4th order and onwards without vectorization (slower)
+    # formula is: d^k f / dr^k = \sum_{j=1}^{k} Bell_{k, j}(...)  (d^jf / dx^j)
+    if total > 4:
+        # Go Through each Pt
+        for i_pt in range(len(r)):
+            # Go through each order from 4 to K + 1
+            for j in range(4, total):
+                # Go through the sum to calculate Bell's polynomial
+                for k in range(j, total):
+                    all_derivs_at_pt = derivs[:, i_pt]
+                    coeff_b[j, i_pt] += (
+                        float(bell(k, j, all_derivs_at_pt)) * coeff_a_mtr[k, i_pt]
+                    )
+    return coeff_b
+
+
+def _transform_ode_from_rtransform(
+    coeff_a: Union[list, np.ndarray], tf: BaseTransform, x: np.ndarray
+):
+    r"""
+    Transform the coefficients of ODE from one variable to another based on Transform object.
+
+    Given a :math:`K`-th differentiable transformation function :math:`g(r)`
+    and a linear ODE of :math:`K`-th order
+
+    .. math::
+        \sum_{k=1}^{K} a_k(r) \frac{d^k y}{d r^k}.
+
+    This transforms it into a new coordinate system with variable :math:`g(r) =: x` via
+
+    .. math::
+        \sum_{j=1}^K b_j(x) \frac{d^j y}{d x^j},
+
+    where :math:`b_j(x) = \sum_{k=1}^K a_k(x) B_{k, j}(g(r), g^\prime(r), \cdots,
+    g^{k - j + 1}(r))`.
+
+    Parameters
+    ----------
+    coeff_a : list[number or callable] or np.ndarray
+        Coefficients for normal ODE
+    tf : BaseTransform
+        Transform instance of :math:`g(x)`
+    x : np.ndarray(N,)
+        Points of the independent variable/domain.
+
+    Returns
+    -------
+    ndarray((K+1, N))
+        Coefficients :math:`b_j(x)` of the new ODE with respect to variable :math:`x`.
+
+    """
+    deriv_func = [tf.deriv, tf.deriv2, tf.deriv3]
+    r = tf.inverse(x)
+    return _transform_ode_from_derivs(coeff_a, deriv_func, r)
+
+
+def _transform_and_rearrange_to_explicit_ode(
+    x: np.ndarray,
+    y: np.ndarray,
+    coeff_a: Union[list, np.ndarray],
+    tf: BaseTransform,
+    fx_func: callable,
+):
+    r"""Rearrange coefficients in transformed domain.
+
+    Parameters
+    ----------
+    x : np.ndarray(N,)
+        Points of the independent variable/domain.
+    y : np.ndarray(K + 1, N)
+        Initial guess for the function values and its derivatives
+    coeff_a : list[number or callable] or np.ndarray(K + 1)
+        Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
+        ordered from 0 to K.  Each coefficient can either be a callable function
+        :math:`a_k(x)` or a constant number :math:`a_k`.
+    tf: BaseTransform
+        Transform instance of :math:`g(x)`.
+    fx_func : Callable
+        Right-hand function of the ODE.
+
+    Returns
+    -------
+    np.ndarray(N,)
+        Expression for the right side of the ODE equation after converting it
+        to explicit form evaluated on all N points.
+
+    """
+    coeff_b = _transform_ode_from_rtransform(coeff_a, tf, x)
+    result = _rearrange_to_explicit_ode(y, coeff_b, fx_func(tf.inverse(x)))
+    return result
+
+
+def _evaluate_coeffs_on_points(x: np.ndarray, coeff: Union[list, np.ndarray]):
+    r"""Construct coefficients of the ODE evaluated on all points.
+
+    Explicitly, constructs a matrix with :math:`(n, k)`-th entry
+    :math:`c_{nk} = a_k(x_n)`,
+
+    where :math:`k`-th coefficient :math:`a_k` from the derivative
+    :math:`\frac{d^k y}{d x^k}` evaluated on the :math:`n`-th term :math:`x_n`.
+
+    Parameters
+    ----------
+    x : ndarray(N,)
+        Points of the independent variable/domain.
+    coeffs : list[callable or float] or ndarray(K + 1,)
+        Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
+        ordered from 0 to K.  Each coefficient can either be a callable function
+        :math:`a_k(x)` or a constant number :math:`a_k`.
+
+    Returns
+    -------
+    np.ndarray(K + 1, N)
+        Coefficients :math:`a_k(x_n)` from the ODE.
+
+    """
+    coeff_mtr = np.zeros((len(coeff), x.size), dtype=float)
+    for i, val in enumerate(coeff):
+        if isinstance(val, Number):
+            coeff_mtr[i] += val
+        elif callable(val):
+            coeff_mtr[i] += val(x)
+        else:
+            raise TypeError(
+                f"Coefficient value {type(val)} is either a number or a function."
             )
-        return res.sol
+    return coeff_mtr
 
-    @staticmethod
-    def _transform_ode_from_derivs(
-        coeffs: Union[list, np.ndarray], deriv_transformation: list, r: np.ndarray
-    ):
-        r"""
-        Transform the coefficients of ODE from one variable to another evaluated on mesh points.
 
-        Given a :math:`K`-th differentiable transformation function :math:`g(r)`
-        and a linear ODE of :math:`K`-th order on independent variable :math:`r`
+def _rearrange_to_explicit_ode(y: np.ndarray, coeff_b: np.ndarray, fx: np.ndarray):
+    r"""Rearrange ODE into explicit form for conversion to first-order ODE (SciPy solver).
 
-        .. math::
-            \sum_{k=1}^{K} a_k(r) \frac{d^k y}{d r^k}.
+    Returns array with :math:`n`-th entry
 
-        This transforms it into a new coordinate system :math:`g(r) =: x`
+    .. math::
+        \frac{f(x_n) -\sum_{k=0}^{K - 1} a_k(x_n) \frac{d^k y(x_n)}{d x^k}}{a_{K}(x_n)},
 
-        .. math::
-            \sum_{j=1}^K b_j(x) \frac{d^j y}{d x^j},
+    of the :math:`n`-th point :math:`x` such that :math:`a_K \neq 0`.
+    This arises from re-arranging the ODE of :math:`K`-th order into explicit form.
+    It is possible that :math:`a_K(x_n) = 0`, it is recommended to split the points
+    into separate intervals and solve them separately.
 
-        where :math:`b_j(x) = \sum_{k=1}^K a_k(x) B_{k, j}(g(r), g^\prime(r), \cdots,
-        g^{k - j + 1}(r))`.
+    Parameters
+    ----------
+    y : np.ndarray(K + 1, N)
+        Initial guess for the function values and its :math:`k`-th order derivatives
+        from 1 to :math:`K`, evaluated on the :math:`n`-th point :math:`x_n`.
+    coeff_b : ndarray(K + 1, N)
+        Coefficients :math:`a_k(x_n)` of each term :math:`\frac{d^k y(x)}{d x^k}`
+        ordered from 0 to K evaluated on the :math:`n`-th point :math:`x_n`.
+    fx : np.ndarray(N,)
+        Right hand-side of the ODE equation, function :math:`f(x_n)` evaluated on the
+        :math:`n`-th point :math:`x_n`.
 
-        Parameters
-        ----------
-        coeffs : list[callable or number] or ndarray
-            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d r^k}`
-            ordered from 0 to K. Either a list of callable functions :math:`a_k(r)` that depends
-            on :math:`r` or array of constants :math:`\{a_k\}_{k=0}^{K}`.
-        deriv_transformation : list[callable]
-            List of functions for compute transformation derivatives from 1 to :math:`K`.
-        r : ndarray
-            Points from the original domain that is to be transformed.
+    Returns
+    -------
+    np.ndarray(N,)
+        Expression for the right side of the ODE equation after converting it
+        to explicit form evaluated on N-th points.
 
-        Returns
-        -------
-        ndarray((K+1, N))
-            Coefficients :math:`b_j(x)` of the new ODE with respect to variable :math:`x`.
+    """
+    if np.any(np.abs(coeff_b[-1]) < 1e-10):
+        warnings.warn("The coefficient of the leading Kth term is zero at some point."
+                      "It is recommended to split into intervals and solve separately.")
 
-        """
-        # `derivs` has shape (K, N), calculate d^j g/ dr^j
-        derivs = np.array([dev(r) for dev in deriv_transformation], dtype=np.float64)
-        total = len(coeffs)  # Should be K+1, K is the order of the ODE
-        # coeff_a_mtr has shape (K+1, N)
-        coeff_a_mtr = ODE._evaluate_coeffs_on_points(r, coeffs)
-        coeff_b = np.zeros((total, r.size), dtype=float)
-        # The first term doesn't contain a derivative so no transformation is required:
-        coeff_b[0] += coeff_a_mtr[0]
-        # construct 1 - 3 directly with vectorization (faster)
-        if total > 1:
-            coeff_b[1] += coeff_a_mtr[1] * derivs[0]
-        if total > 2:
-            coeff_b[1] += coeff_a_mtr[2] * derivs[1]
-            coeff_b[2] += coeff_a_mtr[2] * derivs[0] ** 2
-        if total > 3:
-            coeff_b[1] += coeff_a_mtr[3] * derivs[2]
-            coeff_b[2] += coeff_a_mtr[3] * 3 * derivs[0] * derivs[1]
-            coeff_b[3] += coeff_a_mtr[3] * derivs[0] ** 3
+    result = fx
+    # Go through all rows except the last-element.
+    for i, b in enumerate(coeff_b[:-1]):
+        # array of size N: a_k(x_n) * (d^k y(x_n) / d x^k)
+        result -= b * y[i]
 
-        # construct 4th order and onwards without vectorization (slower)
-        # formula is: d^k f / dr^k = \sum_{j=1}^{k} Bell_{k, j}(...)  (d^jf / dx^j)
-        if total > 4:
-            # Go Through each Pt
-            for i_pt in range(len(r)):
-                # Go through each order from 4 to K + 1
-                for j in range(4, total):
-                    # Go through the sum to calculate Bell's polynomial
-                    for k in range(j, total):
-                        all_derivs_at_pt = derivs[:, i_pt]
-                        coeff_b[j, i_pt] += (
-                            float(bell(k, j, all_derivs_at_pt)) * coeff_a_mtr[k, i_pt]
-                        )
-        return coeff_b
-
-    @staticmethod
-    def _transform_ode_from_rtransform(
-        coeff_a: Union[list, np.ndarray], tf: BaseTransform, x: np.ndarray
-    ):
-        r"""
-        Transform the coefficients of ODE from one variable to another based on Transform object.
-
-        Given a :math:`K`-th differentiable transformation function :math:`g(r)`
-        and a linear ODE of :math:`K`-th order
-
-        .. math::
-            \sum_{k=1}^{K} a_k(r) \frac{d^k y}{d r^k}.
-
-        This transforms it into a new coordinate system with variable :math:`g(r) =: x` via
-
-        .. math::
-            \sum_{j=1}^K b_j(x) \frac{d^j y}{d x^j},
-
-        where :math:`b_j(x) = \sum_{k=1}^K a_k(x) B_{k, j}(g(r), g^\prime(r), \cdots,
-        g^{k - j + 1}(r))`.
-
-        Parameters
-        ----------
-        coeff_a : list[number or callable] or np.ndarray
-            Coefficients for normal ODE
-        tf : BaseTransform
-            Transform instance of :math:`g(x)`
-        x : np.ndarray(N,)
-            Points of the independent variable/domain.
-
-        Returns
-        -------
-        ndarray((K+1, N))
-            Coefficients :math:`b_j(x)` of the new ODE with respect to variable :math:`x`.
-
-        """
-        deriv_func = [tf.deriv, tf.deriv2, tf.deriv3]
-        r = tf.inverse(x)
-        return ODE._transform_ode_from_derivs(coeff_a, deriv_func, r)
-
-    @staticmethod
-    def _transform_and_rearrange_to_explicit_ode(
-        x: np.ndarray,
-        y: np.ndarray,
-        coeff_a: Union[list, np.ndarray],
-        tf: BaseTransform,
-        fx_func: callable,
-    ):
-        r"""Rearrange coefficients in transformed domain.
-
-        Parameters
-        ----------
-        x : np.ndarray(N,)
-            Points of the independent variable/domain.
-        y : np.ndarray(K + 1, N)
-            Initial guess for the function values and its derivatives
-        coeff_a : list[number or callable] or np.ndarray(K + 1)
-            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
-            ordered from 0 to K.  Each coefficient can either be a callable function
-            :math:`a_k(x)` or a constant number :math:`a_k`.
-        tf: BaseTransform
-            Transform instance of :math:`g(x)`.
-        fx_func : Callable
-            Right-hand function of the ODE.
-
-        Returns
-        -------
-        np.ndarray(N,)
-            Expression for the right side of the ODE equation after converting it
-            to explicit form evaluated on all N points.
-
-        """
-        coeff_b = ODE._transform_ode_from_rtransform(coeff_a, tf, x)
-        result = ODE._rearrange_to_explicit_ode(y, coeff_b, fx_func(tf.inverse(x)))
-        return result
-
-    @staticmethod
-    def _evaluate_coeffs_on_points(x: np.ndarray, coeff: Union[list, np.ndarray]):
-        r"""Construct coefficients of the ODE evaluated on all points.
-
-        Explicitly, constructs a matrix with :math:`(n, k)`-th entry
-        :math:`c_{nk} = a_k(x_n)`,
-
-        where :math:`k`-th coefficient :math:`a_k` from the derivative
-        :math:`\frac{d^k y}{d x^k}` evaluated on the :math:`n`-th term :math:`x_n`.
-
-        Parameters
-        ----------
-        x : ndarray(N,)
-            Points of the independent variable/domain.
-        coeffs : list[callable or float] or ndarray(K + 1,)
-            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
-            ordered from 0 to K.  Each coefficient can either be a callable function
-            :math:`a_k(x)` or a constant number :math:`a_k`.
-
-        Returns
-        -------
-        np.ndarray(K + 1, N)
-            Coefficients :math:`a_k(x_n)` from the ODE.
-
-        """
-        coeff_mtr = np.zeros((len(coeff), x.size), dtype=float)
-        for i, val in enumerate(coeff):
-            if isinstance(val, Number):
-                coeff_mtr[i] += val
-            elif callable(val):
-                coeff_mtr[i] += val(x)
-            else:
-                raise TypeError(
-                    f"Coefficient value {type(val)} is either a number or a function."
-                )
-        return coeff_mtr
-
-    @staticmethod
-    def _rearrange_to_explicit_ode(y: np.ndarray, coeff_b: np.ndarray, fx: np.ndarray):
-        r"""Rearrange ODE into explicit form for conversion to first-order ODE (SciPy solver).
-
-        Returns array with :math:`n`-th entry
-
-        .. math::
-            \frac{f(x_n) -\sum_{k=0}^{K - 1} a_k(x_n) \frac{d^k y(x_n)}{d x^k}}{a_{K}(x_n)},
-
-        of the :math:`n`-th point :math:`x` such that :math:`a_K \neq 0`.
-        This arises from re-arranging the ODE of :math:`K`-th order into explicit form.
-        It is possible that :math:`a_K(x_n) = 0`, it is recommended to split the points
-        into separate intervals and solve them separately.
-
-        Parameters
-        ----------
-        y : np.ndarray(K + 1, N)
-            Initial guess for the function values and its :math:`k`-th order derivatives
-            from 1 to :math:`K`, evaluated on the :math:`n`-th point :math:`x_n`.
-        coeff_b : ndarray(K + 1, N)
-            Coefficients :math:`a_k(x_n)` of each term :math:`\frac{d^k y(x)}{d x^k}`
-            ordered from 0 to K evaluated on the :math:`n`-th point :math:`x_n`.
-        fx : np.ndarray(N,)
-            Right hand-side of the ODE equation, function :math:`f(x_n)` evaluated on the
-            :math:`n`-th point :math:`x_n`.
-
-        Returns
-        -------
-        np.ndarray(N,)
-            Expression for the right side of the ODE equation after converting it
-            to explicit form evaluated on N-th points.
-
-        """
-        if np.any(np.abs(coeff_b[-1]) < 1e-10):
-            warnings.warn("The coefficient of the leading Kth term is zero at some point."
-                          "It is recommended to split into intervals and solve separately.")
-
-        result = fx
-        # Go through all rows except the last-element.
-        for i, b in enumerate(coeff_b[:-1]):
-            # array of size N: a_k(x_n) * (d^k y(x_n) / d x^k)
-            result -= b * y[i]
-
-        return result / coeff_b[-1]
+    return result / coeff_b[-1]

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -163,6 +163,8 @@ def solve_ode(
             interpolated = res.sol(transf_pts)  # Row is which func/deriv and Col is points.
             # If derivatives are not wanted then only return y(x).
             if no_derivatives:
+                if interpolated.ndim == 1:
+                    return interpolated
                 return interpolated[0, :]
             deriv_funcs = [transform.deriv, transform.deriv2, transform.deriv3]
             new_interpolate = np.zeros(interpolated.shape)

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -32,27 +32,67 @@ from sympy import bell
 
 
 class ODE:
-    """General ordinary differential equation solver."""
+    r"""
+    Linear ordinary differential equation solver with boundary conditions.
+
+    Solves a linear ordinary differential equation of order :math:`K` of the form
+
+    .. math::
+        \sum_{k=0}^{K} a_k(x) \frac{d^k y(x)}{dx^k} = f(x)
+
+    with boundary conditions on the two end-points for some unknown function
+    :math:`y(x)` with independent variable :math:`x`. Currently only supports :math:`K`-th
+    order less than or equal to three.
+
+    It also supports the ability to transform the independent variable :math:`x`
+    to another domain :math:`g(x)` for some :math:`K`-th differentiable transformation
+    :math:`g(x)`.  This is particularly useful to convert infinite domains, e.g.
+    :math:`[0, \infty)`, to a finite interval.
+
+    """
 
     @staticmethod
-    def solve_ode(x, fx, coeffs, bd_cond, transform=None):
-        """Solve generic boundary condition ODE.
-
-        .. math::
-            ...
+    def solve_ode(
+        x: np.ndarray,
+        fx: callable,
+        coeffs: Union[list, np.ndarray],
+        bd_cond: list,
+        transform: BaseTransform = None,
+        tol: float = 1e-4,
+        max_nodes: int = 5000,
+        initial_guess_y: np.ndarray = None,
+    ):
+        r"""Solve a linear ODE with boundary conditions.
 
         Parameters
         ----------
         x : np.ndarray(N,)
-            Points from domain for solver ODE
+            Points of the independent variable/domain.
         fx : callable
-            Non homogeneous term in ODE
-        coeffs : list[int or callable] or np.ndarray(K,)
-            Coefficients of each differential term
-        bd_cond : iterable
-            Boundary condition for specific solution
+            Right-hand function :math:`f(x)`.
+        coeffs : list[callable or float] or ndarray(K + 1,)
+            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
+            ordered from 0 to K. Either a list of callable functions :math:`a_k(x)` that depends
+            on :math:`x` or array of constants :math:`\{a_k\}_{k=0}^{K}`.
+        bd_cond : list[list[int, int, float]]
+            Boundary condition specified by list of three entries [i, j, C], where
+            :math:`i \in \{0, 1\}` determines whether the lower or upper bound is being
+            constrained, :math:`j \in \{0, \cdots, K\}` determines which derivative
+            :math:`\frac{d^j y}{dx^j}` is being constrained, and :math:`C`
+            determines the boundary constraint value, i.e. :math:`\frac{d^j y}{dx^j} = C`.
+            If `transform` is given, then the constraint of the derivatives is assumed
+            to be with respect to the new coordinate i.e. :math:`\frac{d^j y}{dr^j} = C`.
         transform : BaseTransform, optional
-            Transformation instance r -> x
+            Transformation from one domain :math:`x` to another :math:`r := g(x)`.
+        tol : float, optional
+            Tolerance of the ODE solver and for the boundary condition residuals.
+            See `scipy.integrate.solve_bvp` for more info.
+        max_nodes : int, optional
+            The maximum number of mesh nodes that determine termination.
+            See `scipy.integrate.solve_bvp` function for more info.
+        initial_guess_y : ndarray, optional
+            Initial guess for :math:`y(x)` at the points `x`. If not provided, then
+            random set of points from 0 to 1 is used.
 
         Returns
         -------
@@ -97,44 +137,42 @@ class ODE:
         return res.sol
 
     @staticmethod
-    def _transformed_coeff_ode(coeff_a, tf, x):
-        """Compute coeff for transformed domain.
+    def _transform_ode_from_derivs(
+        coeffs: Union[list, np.ndarray], deriv_transformation: list, r: np.ndarray
+    ):
+        r"""
+        Transform the coefficients of ODE from one variable to another evaluated on mesh points.
+
+        Given a :math:`K`-th differentiable transformation function :math:`g(r)`
+        and a linear ODE of :math:`K`-th order on independent variable :math:`r`
+
+        .. math::
+            \sum_{k=1}^{K} a_k(r) \frac{d^k y}{d r^k}.
+
+        This transforms it into a new coordinate system :math:`g(r) =: x`
+
+        .. math::
+            \sum_{j=1}^K b_j(x) \frac{d^j y}{d x^j},
+
+        where :math:`b_j(x) = \sum_{k=1}^K a_k(x) B_{k, j}(g(r), g^\prime(r), \cdots,
+        g^{k - j + 1}(r))`.
 
         Parameters
         ----------
-        coeff_a : list[number or callable] or np.ndarray
-            Coefficients for normal ODE
-        tf : BaseTransform
-            Transform instance form r -> x
-        x : np.ndarray(N,)
-            Points in the transformed domain
+        coeffs : list[callable or number] or ndarray
+            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d r^k}`
+            ordered from 0 to K. Either a list of callable functions :math:`a_k(r)` that depends
+            on :math:`r` or array of constants :math:`\{a_k\}_{k=0}^{K}`.
+        deriv_transformation : list[callable]
+            List of functions for compute transformation derivatives from 1 to :math:`K`.
+        r : ndarray
+            Points from the original domain that is to be transformed.
 
         Returns
         -------
-        np.ndarray
-            Coefficients for transformed ODE
-        """
-        deriv_func = [tf.deriv, tf.deriv2, tf.deriv3]
-        r = tf.inverse(x)
-        return ODE._transformed_coeff_ode_with_r(coeff_a, deriv_func, r)
+        ndarray((K+1, N))
+            Coefficients :math:`b_j(x)` of the new ODE with respect to variable :math:`x`.
 
-    @staticmethod
-    def _transformed_coeff_ode_with_r(coeff_a, deriv_func_list, r):
-        """Convert higher order ODE into 1st order ODE with original domain r.
-
-        Parameters
-        ----------
-        coeff_a : list[callable or numnber] or np.ndarray
-            Coefficients for each differential part
-        deriv_func_list : list[Callable]
-            A list of functions for compute transformation derivatives
-        r : np.ndarray
-            Points from the non-transformed domain
-
-        Returns
-        -------
-        np.ndarray
-            Coefficients for transformed ODE
         """
         derivs = np.array([dev(r) for dev in deriv_func_list])
         total = len(coeff_a)
@@ -171,26 +209,76 @@ class ODE:
         return coeff_b
 
     @staticmethod
-    def _rearrange_trans_ode(x, y, coeff_a, tf, fx_func):
-        """Rearrange coefficients in transformed domain.
+    def _transform_ode_from_rtransform(
+        coeff_a: Union[list, np.ndarray], tf: BaseTransform, x: np.ndarray
+    ):
+        r"""
+        Transform the coefficients of ODE from one variable to another based on Transform object.
+
+        Given a :math:`K`-th differentiable transformation function :math:`g(r)`
+        and a linear ODE of :math:`K`-th order
+
+        .. math::
+            \sum_{k=1}^{K} a_k(r) \frac{d^k y}{d r^k}.
+
+        This transforms it into a new coordinate system with variable :math:`g(r) =: x` via
+
+        .. math::
+            \sum_{j=1}^K b_j(x) \frac{d^j y}{d x^j},
+
+        where :math:`b_j(x) = \sum_{k=1}^K a_k(x) B_{k, j}(g(r), g^\prime(r), \cdots,
+        g^{k - j + 1}(r))`.
 
         Parameters
         ----------
-        x : np.ndarray(n,)
-            points from desired domain
-        y : np.ndarray(order, n)
-            initial guess for the function values and its derivatives
-        coeff_a : list[number or callable] or np.ndarray(Order + 1)
-            Coefficients for each differential from non-transformed part on ODE
+        coeff_a : list[number or callable] or np.ndarray
+            Coefficients for normal ODE
+        tf : BaseTransform
+            Transform instance of :math:`g(x)`
+        x : np.ndarray(N,)
+            Points of the independent variable/domain.
+
+        Returns
+        -------
+        ndarray((K+1, N))
+            Coefficients :math:`b_j(x)` of the new ODE with respect to variable :math:`x`.
+
+        """
+        deriv_func = [tf.deriv, tf.deriv2, tf.deriv3]
+        r = tf.inverse(x)
+        return ODE._transform_ode_from_derivs(coeff_a, deriv_func, r)
+
+    @staticmethod
+    def _transform_and_rearrange_to_explicit_ode(
+        x: np.ndarray,
+        y: np.ndarray,
+        coeff_a: Union[list, np.ndarray],
+        tf: BaseTransform,
+        fx_func: callable,
+    ):
+        r"""Rearrange coefficients in transformed domain.
+
+        Parameters
+        ----------
+        x : np.ndarray(N,)
+            Points of the independent variable/domain.
+        y : np.ndarray(K + 1, N)
+            Initial guess for the function values and its derivatives
+        coeff_a : list[number or callable] or np.ndarray(K + 1)
+            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
+            ordered from 0 to K.  Each coefficient can either be a callable function
+            :math:`a_k(x)` or a constant number :math:`a_k`.
         tf: BaseTransform
-            transform instance r -> x
+            Transform instance of :math:`g(x)`.
         fx_func : Callable
-            Non-homogeneous term at given x
+            Right-hand function of the ODE.
 
         Returns
         -------
         np.ndarray(N,)
-            proper expr for the right side of the transformed ODE equation
+            Expression for the right side of the ODE equation after converting it
+            to explicit form evaluated on all N points.
+
         """
         coeff_b = ODE._transformed_coeff_ode(coeff_a, tf, x)
         result = ODE._rearrange_ode(x, y, coeff_b, fx_func(tf.inverse(x)))
@@ -221,27 +309,39 @@ class ODE:
         return coeff_mtr
 
     @staticmethod
-    def _rearrange_ode(x, y, coeff_b, fx):
-        """Rearrange coefficients for scipy solver.
+    def _rearrange_to_explicit_ode(y: np.ndarray, coeff_b: np.ndarray, fx: np.ndarray):
+        r"""Rearrange ODE into explicit form for conversion to first-order ODE (SciPy solver).
+
+        Returns array with :math:`n`-th entry
+
+        .. math::
+            \frac{f(x_n) -\sum_{k=0}^{K - 1} a_k(x_n) \frac{d^k y(x_n)}{d x^k}}{a_{K}(x_n)},
+
+        of the :math:`n`-th point :math:`x` such that :math:`a_K \neq 0`.
+        This arises from re-arranging the ODE of :math:`K`-th order into explicit form.
 
         Parameters
         ----------
-        x : np.ndarray(N,)
-            Points from desired domain
-        y : np.ndarray(order, N)
-            Initial guess for the function values and its derivatives
-        coeff_b : list[number] or np.ndarray(Order + 1)
-            Coefficients for each differential part on ODE
+        y : np.ndarray(K + 1, N)
+            Initial guess for the function values and its :math:`k`-th order derivatives
+            from 1 to :math:`K`, evaluated on the :math:`n`-th point :math:`x_n`.
+        coeff_b : ndarray(K + 1, N)
+            Coefficients :math:`a_k(x_n)` of each term :math:`\frac{d^k y(x)}{d x^k}`
+            ordered from 0 to K evaluated on the :math:`n`-th point :math:`x_n`.
         fx : np.ndarray(N,)
-            Non-homogeneous term at given x
+            Right hand-side of the ODE equation, function :math:`f(x_n)` evaluated on the
+            :math:`n`-th point :math:`x_n`.
 
         Returns
         -------
         np.ndarray(N,)
-            proper expr for the right side of the ODE equation
+            Expression for the right side of the ODE equation after converting it
+            to explicit form evaluated on N-th points.
+
         """
         result = fx
+        # Go through all rows except the last-element.
         for i, b in enumerate(coeff_b[:-1]):
-            # if isinstance(b, Number):
+            # array of size N: a_k(x_n) * (d^k y(x_n) / d x^k)
             result -= b * y[i]
         return result / coeff_b[-1]

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -18,16 +18,17 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """Generic ode solver module."""
-# from numbers import Number
 
-# from grid.rtransform import InverseRTransform
 from numbers import Number
+from typing import Union
+
+from grid.rtransform import BaseTransform
 
 import numpy as np
 
 from scipy.integrate import solve_bvp
 
-# from sympy import bell
+from sympy import bell
 
 
 class ODE:

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -293,20 +293,29 @@ class ODE:
         return result
 
     @staticmethod
-    def _construct_coeff_array(x, coeff):
-        """Construct coefficient matrix for given points.
+    def _evaluate_coeffs_on_points(x: np.ndarray, coeff: Union[list, np.ndarray]):
+        r"""Construct coefficients of the ODE evaluated on all points.
+
+        Explicitly, constructs a matrix with :math:`(n, k)`-th entry
+        :math:`c_{nk} = a_k(x_n)`,
+
+        where :math:`k`-th coefficient :math:`a_k` from the derivative
+        :math:`\frac{d^k y}{d x^k}` evaluated on the :math:`n`-th term :math:`x_n`.
 
         Parameters
         ----------
-        x : np.ndarray(K,)
-            Points on the mesh grid
-        coeff : list[number or callable] or np.ndarray, length N
-            Coefficient for each derivatives in the ode
+        x : ndarray(N,)
+            Points of the independent variable/domain.
+        coeffs : list[callable or float] or ndarray(K + 1,)
+            Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
+            ordered from 0 to K.  Each coefficient can either be a callable function
+            :math:`a_k(x)` or a constant number :math:`a_k`.
 
         Returns
         -------
-        np.ndarray(N, K)
-            Numerical coefficient value for ODE
+        np.ndarray(K + 1, N)
+            Coefficients :math:`a_k(x_n)` from the ODE.
+
         """
         coeff_mtr = np.zeros((len(coeff), x.size), dtype=float)
         for i, val in enumerate(coeff):

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -25,8 +25,7 @@ Solves a linear ordinary differential equation of order :math:`K` of the form
     \sum_{k=0}^{K} a_k(x) \frac{d^k y(x)}{dx^k} = f(x)
 
 with boundary conditions on the two end-points for some unknown function
-:math:`y(x)` with independent variable :math:`x`. Currently only supports :math:`K`-th
-order less than or equal to three.
+:math:`y(x)` with independent variable :math:`x`.
 
 It also supports the ability to transform the independent variable :math:`x`
 to another domain :math:`g(x)` for some :math:`K`-th differentiable transformation

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -21,6 +21,7 @@
 
 from numbers import Number
 from typing import Union
+import warnings
 
 from grid.rtransform import BaseTransform
 
@@ -340,6 +341,8 @@ class ODE:
 
         of the :math:`n`-th point :math:`x` such that :math:`a_K \neq 0`.
         This arises from re-arranging the ODE of :math:`K`-th order into explicit form.
+        It is possible that :math:`a_K(x_n) = 0`, it is recommended to split the points
+        into separate intervals and solve them separately.
 
         Parameters
         ----------
@@ -360,9 +363,14 @@ class ODE:
             to explicit form evaluated on N-th points.
 
         """
+        if np.any(np.abs(coeff_b[-1]) < 1e-10):
+            warnings.warn("The coefficient of the leading Kth term is zero at some point."
+                          "It is recommended to split into intervals and solve separately.")
+
         result = fx
         # Go through all rows except the last-element.
         for i, b in enumerate(coeff_b[:-1]):
             # array of size N: a_k(x_n) * (d^k y(x_n) / d x^k)
             result -= b * y[i]
+
         return result / coeff_b[-1]

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -288,8 +288,8 @@ class ODE:
             to explicit form evaluated on all N points.
 
         """
-        coeff_b = ODE._transformed_coeff_ode(coeff_a, tf, x)
-        result = ODE._rearrange_ode(x, y, coeff_b, fx_func(tf.inverse(x)))
+        coeff_b = ODE._transform_ode_from_rtransform(coeff_a, tf, x)
+        result = ODE._rearrange_to_explicit_ode(y, coeff_b, fx_func(tf.inverse(x)))
         return result
 
     @staticmethod
@@ -312,8 +312,12 @@ class ODE:
         for i, val in enumerate(coeff):
             if isinstance(val, Number):
                 coeff_mtr[i] += val
-            else:
+            elif callable(val):
                 coeff_mtr[i] += val(x)
+            else:
+                raise TypeError(
+                    f"Coefficient value {type(val)} is either a number or a function."
+                )
         return coeff_mtr
 
     @staticmethod

--- a/src/grid/poisson.py
+++ b/src/grid/poisson.py
@@ -1,6 +1,6 @@
 """Poisson solver module."""
 
-from grid.interpolate import compute_spline_point_value, generate_real_sph_harms
+from grid.interpolate import project_function_onto_spherical_expansion, generate_real_sph_harms
 from grid.ode import solve_ode
 
 import numpy as np
@@ -47,7 +47,7 @@ class Poisson:
         ms, ls = real_sph.shape[:-1]
         # store spline for each p^{lm}
         spls_mtr = np.zeros((ms, ls), dtype=object)
-        ml_sph_value = compute_spline_point_value(
+        ml_sph_value = project_function_onto_spherical_expansion(
             real_sph, value_array, weights, indices
         )
         ml_sph_value /= (radial.points ** 2 * radial.weights)[:, None, None]
@@ -128,7 +128,7 @@ class Poisson:
             bd_cond = [(0, 0, 0), (1, 0, boundary)]
         else:
             bd_cond = [(0, 0, 0), (1, 0, 0)]
-        return ODE.solve_ode(x_range, f_x, coeffs, bd_cond, transform=tfm)
+        return solve_ode(x_range, f_x, coeffs, bd_cond, transform=tfm)
 
     @staticmethod
     def interpolate_radial(spls_mtr, rad, deriv=0, sumup=False):

--- a/src/grid/poisson.py
+++ b/src/grid/poisson.py
@@ -1,7 +1,7 @@
 """Poisson solver module."""
 
 from grid.interpolate import compute_spline_point_value, generate_real_sph_harms
-from grid.ode import ODE
+from grid.ode import solve_ode
 
 import numpy as np
 

--- a/src/grid/tests/test_ode.py
+++ b/src/grid/tests/test_ode.py
@@ -172,6 +172,7 @@ def test_transform_and_rearrange_to_explicit_ode_with_simple_boundary(transform,
     ],
 )
 def test_solve_ode_with_and_without_transormation(transform, fx, coeffs, bd_cond):
+    r"""Test solve_ode with and without transformation with different bd conditions."""
     x = np.linspace(0.01, 0.999, 20)
     transf_pts = transform.transform(x)
     sol_with_transform = solve_ode(
@@ -261,11 +262,7 @@ def test_construct_coeffs_of_ode_over_mesh():
 
 
 def test_transform_coeff_with_x_and_r():
-    """
-    Test coefficient transform between x and r.
-
-    TODO: Delete this test, it's pretty useless.
-    """
+    """Test coefficient transform between x and r."""
     coeff = np.array([2, 3, 4])
     ltf = LinearTF(1, 10)  # (-1, 1) -> (r0, rmax)
     inv_tf = InverseTF(ltf)  # (r0, rmax) -> (-1, 1)

--- a/src/grid/tests/test_ode.py
+++ b/src/grid/tests/test_ode.py
@@ -22,6 +22,8 @@
 from numbers import Number
 from unittest import TestCase
 
+import pytest
+
 from grid.ode import (
     solve_ode,
     _evaluate_coeffs_on_points,
@@ -34,479 +36,37 @@ from grid.onedgrid import GaussLaguerre
 from grid.rtransform import (
     BaseTransform,
     BeckeRTransform,
+    MultiExpTF,
+    KnowlesTF,
     IdentityRTransform,
     InverseRTransform,
     LinearFiniteRTransform,
 )
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import assert_allclose, assert_almost_equal, assert_raises
 
 from scipy.integrate import solve_bvp
 
+# List of constant right-hand side terms
+def fx_ones(x):
+    return 1 if isinstance(x, Number) else np.ones(x.size)
 
-class TestODE(TestCase):
-    """ODE solver test class."""
 
-    def test_transform_coeff_with_x_and_r(self):
-        """
-        Test coefficient transform between x and r.
+def fx_complicated_example(x):
+    return 1 / x ** 3 + 3 * x ** 2 + x
 
-        TODO: Delete this test, it's pretty useless.
-        """
-        coeff = np.array([2, 3, 4])
-        ltf = LinearFiniteRTransform(1, 10)  # (-1, 1) -> (r0, rmax)
-        inv_tf = InverseRTransform(ltf)  # (r0, rmax) -> (-1, 1)
-        x = np.linspace(-1, 1, 20)
-        r = ltf.transform(x)
-        assert r[0] == 1
-        assert r[-1] == 10
-        # Transform ODE from [1, 10) to (-1, 1)
-        coeff_transform = _transform_ode_from_rtransform(coeff, inv_tf, x)
-        derivs_fun = [inv_tf.deriv, inv_tf.deriv2, inv_tf.deriv3]
-        coeff_transform_all_pts = _transform_ode_from_derivs(coeff, derivs_fun, r)
-        assert_allclose(coeff_transform, coeff_transform_all_pts)
 
-    def test_transformation_of_ode_with_identity_transform(self):
-        """Test transformation of ODE with identity transform."""
-        # Checks that the identity transform x -> x results in the same answer.
-        # Obtain identity trasnform and derivatives.
-        itf = IdentityRTransform()
-        inv_tf = InverseRTransform(itf)
-        derivs_fun = [inv_tf.deriv, inv_tf.deriv2, inv_tf.deriv3]
-        # d^2y / dx^2 = 1
-        coeff = np.array([0, 0, 1])
-        x = np.linspace(0, 1, 10)
-        # compute transformed coeffs
-        coeff_b = _transform_ode_from_derivs(coeff, derivs_fun, x)
-        # f_x = 0 * x + 1  # 1 for every
-        assert_allclose(coeff_b, np.zeros((3, 10), dtype=float) + coeff[:, None])
+def fx_complicated_example2(x):
+    return 1 / x ** 4
 
-    def test_transformation_of_ode_with_linear_transform(self):
-        """Test transformation of ODE with linear transformation."""
-        x = GaussLaguerre(10).points
-        # Obtain linear transformation with rmin = 1 and rmax = 10.
-        ltf = LinearFiniteRTransform(1, 10)
-        # The inverse is x_i = \frac{r_i - r_{min} - R} {r_i - r_{min} + R}
-        inv_ltf = InverseRTransform(ltf)
-        derivs_fun = [inv_ltf.deriv, inv_ltf.deriv2, inv_ltf.deriv3]
-        # Test with 2y + 3y` + 4y``
-        coeff = np.array([2, 3, 4])
-        coeff_b = _transform_ode_from_derivs(coeff, derivs_fun, x)
-        # assert values
-        assert_allclose(coeff_b[0], np.ones(len(x)) * coeff[0])
-        assert_allclose(coeff_b[1], 1 / 4.5 * coeff[1])
-        assert_allclose(coeff_b[2], (1 / 4.5) ** 2 * coeff[2])
 
-    def test_high_order_transformations_gives_itself(self):
-        r"""Test transforming then transforming back gives back the same result."""
-        # Consider the following transformation x^4 and its derivatives
-        def transf(x):
-            return x**4.0
+def fx_complicated_example3(x):
+    return 1 / x ** 2
 
-        derivs = [
-            lambda x: 4.0 * x**3.0,
-            lambda x: 4.0 * 3.0 * x**2.0,
-            lambda x: 4.0 * 3.0 * 2.0 * x,
-            lambda x: 4.0 * 3.0 * 2.0 * np.array([1.0] * len(x)),
-        ]
 
-        # Consider ODE 2y + 3y` + 4y`` + 5y``` + 6dy^4/dx^4 and transform it
-        coeffs = np.array([2, 3, 4, 5, 6])
-        x = np.arange(1.0, 2.0, 0.01)
-        coeffs_transf = _transform_ode_from_derivs(coeffs, derivs, x)
-        # Transform it back using the derivative of the inverse transformation x^4
-        derivs_invs = [
-            lambda r: 1.0 / (4.0 * r ** (3.0 / 4.0)),
-            lambda r: -3.0 / (16.0 * r ** (7.0 / 4.0)),
-            lambda r: 21.0 / (64.0 * r ** (11.0 / 4.0)),
-            lambda r: -231.0 / (256.0 * r ** (15.0 / 4.0)),
-        ]
-        x_transformed = transf(x)
-        # Go Through Each Points and grab the new coefficients and transform it back
-        for i in range(0, len(x)):
-            coeffs_original = _transform_ode_from_derivs(
-                np.ravel(coeffs_transf[:, i]), derivs_invs, x_transformed[i : i + 1]
-            )
-            # Check that it is the same as hte original transformation.
-            assert_almost_equal(coeffs, np.ravel(coeffs_original))
-
-    def test_rearange_ode_coeff(self):
-        """Test rearange ode coeff and solver result."""
-        coeff_b = [0, 0, 1]
-        x = np.linspace(0, 2, 20)
-        y = np.zeros((2, x.size))  # Initial Guess
-
-        def fx(x):
-            return 1 if isinstance(x, Number) else np.ones(x.size)
-
-        def func(x, y):
-            dy_dx = _rearrange_to_explicit_ode(y, coeff_b, fx(x))
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            # Boundary conditions: zero at endpoints of y
-            return np.array([ya[0], yb[0]])
-
-        res = solve_bvp(func, bc, x, y)
-        # res = 0.5 * x**2 - x
-        assert_almost_equal(res.sol(0)[0], 0)
-        assert_almost_equal(res.sol(1)[0], -0.5)
-        assert_almost_equal(res.sol(2)[0], 0)
-        assert_almost_equal(res.sol(0)[1], -1)
-        assert_almost_equal(res.sol(1)[1], 0)
-        assert_almost_equal(res.sol(2)[1], 1)
-
-        # 2nd example
-        coeff_b_2 = [-3, 2, 1]
-
-        def fx2(x):
-            return -6 * x**2 - x + 10
-
-        def func2(x, y):
-            dy_dx = _rearrange_to_explicit_ode(y, coeff_b_2, fx2(x))
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc2(ya, yb):
-            return np.array([ya[0], yb[0] - 14])
-
-        res2 = solve_bvp(func2, bc2, x, y)
-        # res2 = 2 * x**2 + 3x
-        assert_almost_equal(res2.sol(0)[0], 0)
-        assert_almost_equal(res2.sol(1)[0], 5)
-        assert_almost_equal(res2.sol(2)[0], 14)
-        assert_almost_equal(res2.sol(0)[1], 3)
-        assert_almost_equal(res2.sol(1)[1], 7)
-        assert_almost_equal(res2.sol(2)[1], 11)
-
-    def test_second_order_ode_with_transformation(self):
-        """Test transforming and re-arranging ODE is equivalent without transforming."""
-        stf = SqTF()
-        coeff = np.array([0, 0, 1])
-        # transform
-        r = np.linspace(1, 2, 10)  # r
-        y = np.zeros((2, r.size))
-        x = stf.transform(r)  # transformed x
-        assert_almost_equal(x, r**2)
-
-        def fx(x):
-            return 1 if isinstance(x, Number) else np.ones(x.size)
-
-        # Run with transformation
-        def func(x, y):
-            dy_dx = _transform_and_rearrange_to_explicit_ode(x, y, coeff, stf, fx)
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            # Boundary of y is zero on endpoints
-            return np.array([ya[0], yb[0]])
-
-        res = solve_bvp(func, bc, x, y)
-
-        # Run without transformation
-        ref_y = np.zeros((2, r.size))  # Initial Guess
-
-        def func_ref(x, y):
-            return np.vstack((y[1:], np.ones(y[0].size)))
-
-        # Run without transformation
-        res_ref = solve_bvp(func_ref, bc, r, ref_y)
-        # Check if they're equal
-        assert_allclose(res.sol(x)[0], res_ref.sol(r)[0], atol=1e-4)
-
-    def test_second_order_ode_with_diff_coeff(self):
-        """Test transforming and re-arranging ODE with non-constant function."""
-        stf = SqTF()
-        stf = SqTF(3, 1)
-        coeff = np.array([2, 3, 2])
-        # transform
-        r = np.linspace(1, 2, 10)  # r
-        y = np.zeros((2, r.size))
-        x = stf.transform(r)  # transformed x
-
-        def fx(x):
-            return 1 / x**3 + 3 * x**2 + x
-
-        def func(x, y):
-            dy_dx = _transform_and_rearrange_to_explicit_ode(x, y, coeff, stf, fx)
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            return np.array([ya[0], yb[0]])
-
-        res = solve_bvp(func, bc, x, y)
-        ref_y = np.zeros((2, r.size))
-
-        def func_ref(x, y):
-            return np.vstack((y[1], (fx(x) - 2 * y[0] - 3 * y[1]) / 2))
-
-        res_ref = solve_bvp(func_ref, bc, r, ref_y)
-        assert_allclose(res.sol(x)[0], res_ref.sol(r)[0], atol=1e-4)
-
-    def test_second_order_ode_with_fx(self):
-        """Test ODE with and without transformation with a non-constant term."""
-        stf = SqTF()
-        # Test ode 2y + 2y` + 3y``
-        coeff = np.array([2, 2, 3])
-        # transform
-        r = np.linspace(1, 2, 10)  # r
-        initial_guess = np.zeros((2, r.size))
-        x = stf.transform(r)  # transformed x
-        assert_almost_equal(x, r**2)
-
-        # Non-constant term.
-        def fx(x):
-            return x**2 + 3 * x - 5
-
-        def func(x, y):
-            dy_dx = _transform_and_rearrange_to_explicit_ode(x, y, coeff, stf, fx)
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            return np.array([ya[0], yb[0]])
-
-        res = solve_bvp(func, bc, x, initial_guess)
-
-        def func_ref(x, y):
-            dy_dx = _rearrange_to_explicit_ode(y, coeff, fx(x))
-            return np.vstack((*y[1:], dy_dx))
-
-        res_ref = solve_bvp(func_ref, bc, r, initial_guess)
-        # Test initial gfunctions are similar
-        assert_allclose(res.sol(x)[0], res_ref.sol(r)[0], atol=1e-4)
-        # Test first derivatives are similar
-        assert_allclose(res.sol(x)[1], res_ref.sol(r)[1] / stf.deriv(r), atol=1e-4)
-
-    def test_becke_transform_2nd_order_ode(self):
-        """Test same result for 2nd order ode with becke tf."""
-        btf = BeckeRTransform(0.1, 2)
-        ibtf = InverseRTransform(btf)
-        coeff = np.array([0, 1, 1])
-        # transform
-        # r = np.linspace(1, 2, 10)  # r
-        # x = ibtf.transform(r)  # transformed x
-        x = np.linspace(-0.9, 0.9, 20)
-        r = ibtf.inverse(x)
-        y = np.zeros((2, r.size))
-
-        def fx(x):
-            return 1 / x**2
-
-        def func(x, y):
-            dy_dx = _transform_and_rearrange_to_explicit_ode(x, y, coeff, ibtf, fx)
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            return np.array([ya[0], yb[0]])
-
-        res = solve_bvp(func, bc, x, y)
-
-        def func_ref(x, y):
-            dy_dx = _rearrange_to_explicit_ode(y, coeff, fx(x))
-            return np.vstack((*y[1:], dy_dx))
-
-        res_ref = solve_bvp(func_ref, bc, r, y)
-        print(res_ref.sol(r)[0])
-
-        assert_allclose(res.sol(x)[0], res_ref.sol(r)[0], atol=5e-3)
-
-    def test_becke_transform_3nd_order_ode(self):
-        """Test third order ode with Becke transformation against without transformation."""
-        btf = BeckeRTransform(0.1, 10)
-        ibtf = InverseRTransform(btf)
-        # Consider ODE 2y^` + 3y^`` + 3 * dy^3/dx^3 = 1/x^4
-        coeff = np.array([0, 2, 3, 3])
-        # transform
-        x = np.linspace(-0.9, 0.9, 20)
-        r = btf.transform(x)
-        initial_guess = np.random.rand(3, r.size)
-
-        def fx(x):
-            return 1 / x**4
-
-        def func(x, y):
-            dy_dx = _transform_and_rearrange_to_explicit_ode(x, y, coeff, ibtf, fx)
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            return np.array([ya[0], yb[0], ya[1]])
-
-        res = solve_bvp(func, bc, x, initial_guess, tol=1e-12)
-
-        def func_ref(x, y):
-            dy_dx = _rearrange_to_explicit_ode(y, coeff, fx(x))
-            return np.vstack((*y[1:], dy_dx))
-
-        res_ref = solve_bvp(func_ref, bc, r, initial_guess, tol=1e-12)
-        # Test the original, derivative and second order derivative give the same solution.
-        assert_allclose(res.sol(x)[0], res_ref.sol(r)[0], atol=1e-6)
-        assert_allclose(0.0, res_ref.sol(r)[1][0])  # Test upper-bound.
-        assert_allclose(res.sol(x)[1], res_ref.sol(r)[1] * btf.deriv(x), atol=1e-6)
-        assert_allclose(
-            res.sol(x)[2],
-            res_ref.sol(r)[2] / ibtf.deriv(r) ** 2.0
-            + res_ref.sol(r)[1] * -ibtf.deriv2(r) / ibtf.deriv(r) ** 3.0,
-            atol=1e-6,
-        )
-
-    def test_becke_transform_f0_ode(self):
-<<<<<<< HEAD
-        """Test same result for 3rd order ode with becke tf and fx term."""
-        btf = BeckeRTransform(0.1, 10)
-        x = np.linspace(-0.9, 0.9, 20)
-        btf = BeckeRTransform(0.1, 5)
-        ibtf = InverseRTransform(btf)
-=======
-        """Test second order ode with (without) Becke transformation and non-constant term."""
-        x = np.linspace(-0.9, 0.9, 10)
-        btf = BeckeTF(0.1, 5)
-        ibtf = InverseTF(btf)
->>>>>>> Change test names and add documentation in ode
-        r = btf.transform(x)
-        initial_guess = np.random.rand(2, x.size)
-        # ODE is -y - y` + 2y`` = -1/x^2
-        coeff = [-1, -1, 2]
-
-        def fx(x):
-            return -1 / x**2
-
-        def func(x, y):
-            dy_dx = _transform_and_rearrange_to_explicit_ode(x, y, coeff, ibtf, fx)
-            return np.vstack((*y[1:], dy_dx))
-
-        def bc(ya, yb):
-            return np.array([ya[0], yb[0]])
-
-        res = solve_bvp(
-            func, bc, x, initial_guess, tol=1e-12, bc_tol=1e-12, max_nodes=10000
-        )
-
-        def func_ref(x, y):
-            dy_dx = _rearrange_to_explicit_ode(y, coeff, fx(x))
-            return np.vstack((*y[1:], dy_dx))
-
-        res_ref = solve_bvp(
-            func_ref, bc, r, res.sol(x), tol=1e-12, bc_tol=1e-12, max_nodes=10000
-        )
-        # Test the original, derivative give the same solution and boundary condition.
-        assert_allclose(res.sol(x)[0], res_ref.sol(r)[0], atol=1e-6)
-        assert_allclose(
-            res.sol(x)[0][0], 0.0, atol=1e-6
-        )  # Test lower boundary condition
-        assert_allclose(
-            res.sol(x)[0][-1], 0.0, atol=1e-6
-        )  # Test upper boundary condition
-        assert_allclose(res.sol(x)[1], res_ref.sol(r)[1] / ibtf.deriv(r), atol=1e-6)
-
-    def test_solve_ode_bvp_against_analytic_example(self):
-        """Test solve_ode against analytic solution."""
-        x = np.linspace(0, 2, 10)
-
-        def fx(x):
-            return 1 if isinstance(x, Number) else np.ones(x.size)
-
-        # test ode  y^`` = 1
-        coeffs = [0, 0, 1]
-        # lower and upper bound of y is equal to zero.
-        bd_cond = [[0, 0, 0], [1, 0, 0]]
-
-        res = solve_ode(x, fx, coeffs, bd_cond)
-
-        def solution(x):
-            return x**2.0 / 2.0 - x
-
-        def deriv(x):
-            return x - 1.0
-
-        rand_pts = np.random.uniform(0.0, 2.0, size=10)
-        assert_almost_equal(res(rand_pts)[0], solution(rand_pts))
-        assert_almost_equal(res(rand_pts)[1], deriv(rand_pts))
-
-    def test_solver_ode_bvp_with_tf(self):
-        """Test solve_ode with transformation and without transformation."""
-        x = np.linspace(-0.999, 0.999, 20)
-        btf = BeckeRTransform(0.1, 5)
-        r = btf.transform(x)
-        ibtf = InverseRTransform(btf)
-
-        def fx(x):
-            return 1 / x**2
-
-        # Test with ode -y + y` + y``=1/x^2
-        coeffs = [-1, 1, 1]
-        bd_cond = [(0, 0, 3), (1, 0, 3)]  # Test y(a) = y(b) = 3
-        # calculate diff equation wt/w tf.
-        res = solve_ode(x, fx, coeffs, bd_cond, ibtf, tol=1e-7, max_nodes=20000)
-        res_ref = solve_ode(
-            r, fx, coeffs, bd_cond, tol=1e-7, max_nodes=20000, initial_guess_y=res(x)
-        )
-        assert_allclose(res(x)[0], res_ref(r)[0], atol=1e-5)
-        assert_allclose(res(x)[0][0], 3.0, atol=1e-5)  # Test lower boundary condition
-        assert_allclose(res(x)[0][-1], 3.0, atol=1e-5)  # Test upper boundary condition
-        assert_allclose(res(x)[1], res_ref(r)[1] / ibtf.deriv(r), atol=1e-4)
-
-    def test_solver_ode_coeff_a_f_x_with_tf(self):
-        """Test ode with a(x) and f(x) involved."""
-        x = np.linspace(-0.999, 0.999, 20)
-        btf = BeckeRTransform(0.1, 5)
-        r = btf.transform(x)
-        ibtf = InverseRTransform(btf)
-
-        def fx(x):
-            return 0 * x
-
-        coeffs = [lambda x: x**2, lambda x: 1 / x**2, 0.5]
-        bd_cond = [(0, 1, 0.0), (1, 1, 0.0)]
-        # calculate diff equation wt/w tf.
-        res = solve_ode(x, fx, coeffs, bd_cond, ibtf, tol=1e-7, max_nodes=20000)
-        res_ref = solve_ode(r, fx, coeffs, bd_cond)
-        assert_allclose(res(x)[0], res_ref(r)[0], atol=1e-4)
-        assert_allclose(res(x)[1][0], 0.0, atol=1e-5)  # Test lower boundary condition
-        assert_allclose(res(x)[1][-1], 0.0, atol=1e-5)  # Test upper boundary condition
-        assert_allclose(res(x)[1], res_ref(r)[1] / ibtf.deriv(r), atol=1e-4)
-
-    def test_construct_coeffs_of_ode_over_mesh(self):
-        """Test construct coefficients over a mesh."""
-        # first test
-        x = np.linspace(-0.9, 0.9, 20)
-        coeff = [2, 1.5, lambda x: x**2]
-        coeff_a = _evaluate_coeffs_on_points(x, coeff)
-        assert_allclose(coeff_a[0], np.ones(20) * 2)
-        assert_allclose(coeff_a[1], np.ones(20) * 1.5)
-        assert_allclose(coeff_a[2], x**2)
-        # second test
-        coeff = [lambda x: 1 / x, 2, lambda x: x**3, lambda x: np.exp(x)]
-        coeff_a = _evaluate_coeffs_on_points(x, coeff)
-        assert_allclose(coeff_a[0], 1 / x)
-        assert_allclose(coeff_a[1], np.ones(20) * 2)
-        assert_allclose(coeff_a[2], x**3)
-        assert_allclose(coeff_a[3], np.exp(x))
-
-    def test_error_raises(self):
-        """Test proper error raises."""
-        x = np.linspace(-0.999, 0.999, 20)
-        # r = btf.transform(x)
-
-        def fx(x):
-            return 1 / x**2
-
-        coeffs = [-1, -2, 1]
-        bd_cond = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0)]
-        with self.assertRaises(NotImplementedError):
-            solve_ode(x, fx, coeffs, bd_cond[3:])
-        with self.assertRaises(NotImplementedError):
-            solve_ode(x, fx, coeffs, bd_cond)
-        with self.assertRaises(NotImplementedError):
-            test_coeff = [1, 2, 3, 4, 5]
-            solve_ode(x, fx, test_coeff, bd_cond)
-        with self.assertRaises(ValueError):
-            test_coeff = [1, 2, 3, 3]
-            tf = BeckeRTransform(0.1, 1)
-
-            def fx(x):
-                return x
-
-            solve_ode(x, fx, test_coeff, bd_cond[:3], tf)
+def fx_quadratic(x):
+    return x ** 2 + 3 * x - 5
 
 
 class SqTF(BaseTransform):
@@ -536,3 +96,301 @@ class SqTF(BaseTransform):
     def deriv3(self, x):
         """Compute 3rd order deriv of TF."""
         return (self._exp - 2) * (self._exp - 1) * (self._exp) * x ** (self._exp - 3)
+
+
+@pytest.mark.parametrize(
+    "transform, fx, coeffs",
+    [
+        [IdentityRTransform(), fx_ones, [-1, 1, 1]],
+        [SqTF(), fx_ones, np.random.uniform(-100, 100, (3,))],
+        [KnowlesTF(0.01, 1, 5), fx_ones, np.random.uniform(-10, 10, (3,))],
+        [BeckeTF(0.1, 100.), fx_ones, np.random.uniform(0, 100, (3,))],
+        [SqTF(1, 3), fx_complicated_example, np.random.uniform(0, 100, (3,))],
+        [SqTF(3, 1), fx_complicated_example, [2, 3, 2]],
+        [SqTF(), fx_quadratic, np.random.uniform(-100, 100, (3,))],
+        [SqTF(1, 4), fx_complicated_example, np.random.uniform(-10, 10, (3,))],
+        [SqTF(1, 4), fx_complicated_example2, [1, -1, 1]]
+    ],
+)
+def test_transform_and_rearrange_to_explicit_ode_with_simple_boundary(transform, fx, coeffs):
+    r"""Test transforming second-order ode with simple boundary conditions."""
+    x = np.arange(0.1, 0.99, 0.01)
+    transform_pts = transform.transform(x)
+
+    def bc(ya, yb):
+        # Boundary of y is zero on endpoints
+        return np.array([ya[0], yb[0]])
+
+    # Run with transformation
+    def func_with_transform(r, y):
+        # Transform back to original domain x
+        original = transform.inverse(r)
+        # Apply the ode transfomration
+        dy_dx = _transform_and_rearrange_to_explicit_ode(original, y, coeffs, transform, fx)
+        return np.vstack((*y[1:], dy_dx))
+
+    init_guess = np.zeros((2, x.size))
+    solution_with_transf = solve_bvp(func_with_transform, bc, transform_pts, init_guess,
+                                     tol=1e-6, max_nodes=10000, verbose=1)
+
+
+    # Run without transformation
+    def func_without_transform(original_pts, y):
+        coeffs_mt = _evaluate_coeffs_on_points(original_pts, coeffs)
+        dy_dx = _rearrange_to_explicit_ode(y, coeffs_mt, fx(original_pts))
+        return np.vstack((y[1:], dy_dx))
+
+    # Run without transformation
+    solution_without_transf = solve_bvp(func_without_transform, bc, x,
+                                        solution_with_transf.sol(transform_pts), tol=1e-6,
+                                        max_nodes=100000, verbose=1)
+    # Check if the solution at x is the same as the solution (with transform) at r=g(x)
+    assert_allclose(solution_with_transf.sol(transform_pts)[0],
+                    solution_without_transf.sol(x)[0], atol=1e-4)
+    # Check if they're similar at random points on interval with lower accuracy tolerance
+    random_pts = np.random.uniform(np.min(x), np.max(x), transform_pts.shape)
+    transf_pts = transform.transform(random_pts)
+    assert_allclose(solution_with_transf.sol(transf_pts)[0],
+                    solution_without_transf.sol(random_pts)[0], atol=1e-4)
+    # Test the derivative
+    assert_allclose(solution_with_transf.sol(transform_pts)[1],
+                    solution_without_transf.sol(x)[1] / transform.deriv(x), atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "transform, fx, coeffs, bd_cond",
+    [
+        # Test with ode -y + y` + y``=1/x^2
+        [BeckeTF(1.0, 5.), fx_complicated_example3, [-1, 1, 1], [(0, 0, 3), (1, 0, 3)]],
+        [InverseTF(BeckeTF(1.0, 5.)), fx_complicated_example3, [-1, 1, 1], [(0, 0, 3), (1, 0, 3)]],
+        [BeckeTF(1.0, 5.), fx_complicated_example3, [-1, 1, 1], [(0, 0, 3), (1, 0, 3)]],
+        # Test one with boundary conditions on the derivatives
+        [
+            SqTF(1, 3), fx_complicated_example, np.random.uniform(-100, 100, (4,)),
+            [(0, 0, 0), (0, 1, 3), (1, 1, 3)]
+        ],
+    ],
+)
+def test_solve_ode_with_and_without_transormation(transform, fx, coeffs, bd_cond):
+    x = np.linspace(0.01, 0.999, 20)
+    transf_pts = transform.transform(x)
+    sol_with_transform = solve_ode(
+        x, fx, coeffs, bd_cond, transform, tol=1e-8, max_nodes=20000, no_derivatives=False
+    )
+    init_guess = sol_with_transform(x)
+
+    sol_normal = solve_ode(
+        x, fx, coeffs, bd_cond, tol=1e-8, max_nodes=20000, initial_guess_y=init_guess
+    )
+    # Test the function values
+    assert_allclose(sol_with_transform(x)[0], sol_normal(x)[0], atol=1e-5)
+    # Test the boundary condition
+    for bd in bd_cond:
+        bnd, deriv, val = bd
+        assert_allclose(sol_with_transform(x)[deriv][-bnd], val, atol=1e-5)
+    if len(coeffs) >= 3:
+        # Test the first derivative of y.
+        assert_allclose(sol_with_transform(x)[1], sol_normal(x)[1], atol=1e-3)
+        if len(coeffs) >= 4:
+            assert_allclose(sol_with_transform(x)[2], sol_normal(x)[2], atol=1e-3)
+
+
+def test_solve_ode_bvp_against_analytic_example():
+    """Test solve_ode against analytic solution."""
+    x = np.linspace(0, 2, 10)
+
+    def fx(x):
+        return 1 if isinstance(x, Number) else np.ones(x.size)
+
+    # test ode  y^`` = 1
+    coeffs = [0, 0, 1]
+    # lower and upper bound of y is equal to zero.
+    bd_cond = [[0, 0, 0], [1, 0, 0]]
+
+    res = solve_ode(x, fx, coeffs, bd_cond)
+
+    def solution(x):
+        return x**2.0 / 2.0 - x
+
+    def deriv(x):
+        return x - 1.0
+
+    # Test on random points.
+    rand_pts = np.random.uniform(0.0, 2.0, size=10)
+    assert_almost_equal(res(rand_pts)[0], solution(rand_pts))
+    assert_almost_equal(res(rand_pts)[1], deriv(rand_pts))
+
+
+def test_error_raises():
+    """Test proper error raises."""
+    x = np.linspace(-0.999, 0.999, 20)
+    # r = btf.transform(x)
+
+    def fx(x):
+        return 1 / x**2
+
+    coeffs = [-1, -2, 1]
+    bd_cond = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0)]
+    # Test the error that the number of boundary conditions should be equal to order.
+    assert_raises(ValueError, solve_ode, x, fx, coeffs, bd_cond[3:])
+    assert_raises(ValueError, solve_ode, x, fx, coeffs, bd_cond)
+    test_coeff = [1, 2, 3, 4, 5]
+    assert_raises(ValueError, solve_ode, x, fx, test_coeff, bd_cond)
+
+    test_coeff = [1, 2, 3, 3]
+    tf = BeckeTF(0.1, 1)
+    assert_raises(ValueError, solve_ode, x, fx, test_coeff, bd_cond[:3], tf)
+
+
+def test_construct_coeffs_of_ode_over_mesh():
+    """Test construct coefficients over a mesh."""
+    # first test
+    x = np.linspace(-0.9, 0.9, 20)
+    coeff = [2, 1.5, lambda x: x**2]
+    coeff_a = _evaluate_coeffs_on_points(x, coeff)
+    assert_allclose(coeff_a[0], np.ones(20) * 2)
+    assert_allclose(coeff_a[1], np.ones(20) * 1.5)
+    assert_allclose(coeff_a[2], x**2)
+    # second test
+    coeff = [lambda x: 1 / x, 2, lambda x: x**3, lambda x: np.exp(x)]
+    coeff_a = _evaluate_coeffs_on_points(x, coeff)
+    assert_allclose(coeff_a[0], 1 / x)
+    assert_allclose(coeff_a[1], np.ones(20) * 2)
+    assert_allclose(coeff_a[2], x**3)
+    assert_allclose(coeff_a[3], np.exp(x))
+
+
+def test_transform_coeff_with_x_and_r():
+    """
+    Test coefficient transform between x and r.
+
+    TODO: Delete this test, it's pretty useless.
+    """
+    coeff = np.array([2, 3, 4])
+    ltf = LinearTF(1, 10)  # (-1, 1) -> (r0, rmax)
+    inv_tf = InverseTF(ltf)  # (r0, rmax) -> (-1, 1)
+    x = np.linspace(-1, 1, 20)
+    r = ltf.transform(x)
+    assert r[0] == 1
+    assert r[-1] == 10
+    # Transform ODE from [1, 10) to (-1, 1)
+    coeff_transform = _transform_ode_from_rtransform(coeff, inv_tf, x)
+    derivs_fun = [inv_tf.deriv, inv_tf.deriv2, inv_tf.deriv3]
+    coeff_transform_all_pts = _transform_ode_from_derivs(coeff, derivs_fun, r)
+    assert_allclose(coeff_transform, coeff_transform_all_pts)
+
+
+def test_transformation_of_ode_with_identity_transform():
+    """Test transformation of ODE with identity transform."""
+    # Checks that the identity transform x -> x results in the same answer.
+    # Obtain identity trasnform and derivatives.
+    itf = IdentityRTransform()
+    inv_tf = InverseTF(itf)
+    derivs_fun = [inv_tf.deriv, inv_tf.deriv2, inv_tf.deriv3]
+    # d^2y / dx^2 = 1
+    coeff = np.array([0, 0, 1])
+    x = np.linspace(0, 1, 10)
+    # compute transformed coeffs
+    coeff_b = _transform_ode_from_derivs(coeff, derivs_fun, x)
+    # f_x = 0 * x + 1  # 1 for every
+    assert_allclose(coeff_b, np.zeros((3, 10), dtype=float) + coeff[:, None])
+
+
+def test_transformation_of_ode_with_linear_transform():
+    """Test transformation of ODE with linear transformation."""
+    x = GaussLaguerre(10).points
+    # Obtain linear transformation with rmin = 1 and rmax = 10.
+    ltf = LinearTF(1, 10)
+    # The inverse is x_i = \frac{r_i - r_{min} - R} {r_i - r_{min} + R}
+    inv_ltf = InverseTF(ltf)
+    derivs_fun = [inv_ltf.deriv, inv_ltf.deriv2, inv_ltf.deriv3]
+    # Test with 2y + 3y` + 4y``
+    coeff = np.array([2, 3, 4])
+    coeff_b = _transform_ode_from_derivs(coeff, derivs_fun, x)
+    # assert values
+    assert_allclose(coeff_b[0], np.ones(len(x)) * coeff[0])
+    assert_allclose(coeff_b[1], 1 / 4.5 * coeff[1])
+    assert_allclose(coeff_b[2], (1 / 4.5) ** 2 * coeff[2])
+
+
+def test_high_order_transformations_gives_itself():
+    r"""Test transforming then transforming back gives back the same result."""
+    # Consider the following transformation x^4 and its derivatives
+    def transf(x):
+        return x**4.0
+
+    derivs = [
+        lambda x: 4.0 * x**3.0,
+        lambda x: 4.0 * 3.0 * x**2.0,
+        lambda x: 4.0 * 3.0 * 2.0 * x,
+        lambda x: 4.0 * 3.0 * 2.0 * np.array([1.0] * len(x)),
+    ]
+
+    # Consider ODE 2y + 3y` + 4y`` + 5y``` + 6dy^4/dx^4 and transform it
+    coeffs = np.array([2, 3, 4, 5, 6])
+    x = np.arange(1.0, 2.0, 0.01)
+    coeffs_transf = _transform_ode_from_derivs(coeffs, derivs, x)
+    # Transform it back using the derivative of the inverse transformation x^4
+    derivs_invs = [
+        lambda r: 1.0 / (4.0 * r ** (3.0 / 4.0)),
+        lambda r: -3.0 / (16.0 * r ** (7.0 / 4.0)),
+        lambda r: 21.0 / (64.0 * r ** (11.0 / 4.0)),
+        lambda r: -231.0 / (256.0 * r ** (15.0 / 4.0)),
+    ]
+    x_transformed = transf(x)
+    # Go Through Each Points and grab the new coefficients and transform it back
+    for i in range(0, len(x)):
+        coeffs_original = _transform_ode_from_derivs(
+            np.ravel(coeffs_transf[:, i]), derivs_invs, x_transformed[i : i + 1]
+        )
+        # Check that it is the same as hte original transformation.
+        assert_almost_equal(coeffs, np.ravel(coeffs_original))
+
+
+def test_rearange_ode_coeff():
+    """Test rearange ode coeff and solver result."""
+    coeff_b = [0, 0, 1]
+    x = np.linspace(0, 2, 20)
+    y = np.zeros((2, x.size))  # Initial Guess
+
+    def fx(x):
+        return 1 if isinstance(x, Number) else np.ones(x.size)
+
+    def func(x, y):
+        dy_dx = _rearrange_to_explicit_ode(y, coeff_b, fx(x))
+        return np.vstack((*y[1:], dy_dx))
+
+    def bc(ya, yb):
+        # Boundary conditions: zero at endpoints of y
+        return np.array([ya[0], yb[0]])
+
+    res = solve_bvp(func, bc, x, y)
+    # res = 0.5 * x**2 - x
+    assert_almost_equal(res.sol(0)[0], 0)
+    assert_almost_equal(res.sol(1)[0], -0.5)
+    assert_almost_equal(res.sol(2)[0], 0)
+    assert_almost_equal(res.sol(0)[1], -1)
+    assert_almost_equal(res.sol(1)[1], 0)
+    assert_almost_equal(res.sol(2)[1], 1)
+
+    # 2nd example
+    coeff_b_2 = [-3, 2, 1]
+
+    def fx2(x):
+        return -6 * x**2 - x + 10
+
+    def func2(x, y):
+        dy_dx = _rearrange_to_explicit_ode(y, coeff_b_2, fx2(x))
+        return np.vstack((*y[1:], dy_dx))
+
+    def bc2(ya, yb):
+        return np.array([ya[0], yb[0] - 14])
+
+    res2 = solve_bvp(func2, bc2, x, y)
+    # res2 = 2 * x**2 + 3x
+    assert_almost_equal(res2.sol(0)[0], 0)
+    assert_almost_equal(res2.sol(1)[0], 5)
+    assert_almost_equal(res2.sol(2)[0], 14)
+    assert_almost_equal(res2.sol(0)[1], 3)
+    assert_almost_equal(res2.sol(1)[1], 7)
+    assert_almost_equal(res2.sol(2)[1], 11)

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 
 from grid.atomgrid import AtomGrid
-from grid.interpolate import interpolate, spline_with_atomic_grid
+from grid.interpolate import interpolate_given_splines, spline_with_atomic_grid
 from grid.onedgrid import GaussChebyshev
 from grid.poisson import Poisson
 from grid.rtransform import BeckeRTransform, InverseRTransform


### PR DESCRIPTION
This pull-requests refactors ode.py and makes a decent amount of changes.

Features
------------
- Remove the class structure and turn everything into functions (39372cb6d6e88bf2dd0d92fedd78410653df6d9a).
- Improve the documentation with formulas for all functions 
- Add the ability for the user to add their own initial guess and change the max_nodes in scipy.integrate.solve_bvp. This was to make sure the boundaries were satisfying the constraint for more accuracy.
- The code only supported transforming three order ODE, added the ability to transform higher orders (f5ceb2149a6a26cc057b8e621aef12ff664b9166)
- Changed it so that the solution to the ODE when using a transformation to a new coordinate is with respect to the old coordinate rather than the new coordinate.  This also converts higher-order derivatives as well.
- Added a boolean attribute `no_derivatives` to solve_ode if the user knows they don't want the derivatives when using an radial transformation (point above).   This was to improve efficiency as converting derivatives has to occur point-wise with a for-loop.
- Remove the class structure in tests and used pytest.mark.parameterize to try more complicated examples and to clean code (bc4b3db64f62b499620f3deef59e56de845b0206).
- To the tests, I also made sure the nth derivatives are all accurate rather than just the function values (1f3baea3a0e1023744481c07f267eaa90d2576ec).
- Added a warning in case the leading coefficient is zero (cdd9a3ab153113ae98a8cac7d1b5af52169e316b).
 