### PR TITLE
Spherical average

### DIFF
--- a/src/grid/atomgrid.py
+++ b/src/grid/atomgrid.py
@@ -322,7 +322,7 @@ class AtomGrid(Grid):
         # Consider a Gaussian function that takes Cartesian points
         >>> def func(cart_pts):
         >>>     return np.exp(-np.linalg.norm(cart_pts, axis=1)**2.0)
-        #
+        # Construct atomic grid with degree 10 on a radial grid on [0, \infty)
         >>> radial_grid = GaussLaguerre(alpha=1.0)
         >>> atgrid = AtomGrid(radial_grid, degrees=[10])
         >>> func_vals = func(argrid.points)   # Atomic grid points are stored in Cartesian

--- a/src/grid/atomgrid.py
+++ b/src/grid/atomgrid.py
@@ -319,17 +319,19 @@ class AtomGrid(Grid):
 
         Examples
         --------
-        # Consider a Gaussian function that takes Cartesian points
-        >>> def func(cart_pts):
-        >>>     return np.exp(-np.linalg.norm(cart_pts, axis=1)**2.0)
+        # Define a Gaussian function that takes Cartesian coordinates as input
+        >>> func = lambda cart_pts: np.exp(-np.linalg.norm(cart_pts, axis=1)**2.0)
         # Construct atomic grid with degree 10 on a radial grid on [0, \infty)
-        >>> radial_grid = GaussLaguerre(alpha=1.0)
+        >>> radial_grid = GaussLaguerre(100, alpha=1.0)
         >>> atgrid = AtomGrid(radial_grid, degrees=[10])
-        >>> func_vals = func(argrid.points)   # Atomic grid points are stored in Cartesian
-        >>> spherical_avg = atgrid.spherical_average(funv_vals)
-        # Evaluate the spherical avg on a set of points in [0, \infty)
+        # Evaluate func on atmic grid points (which are stored in Cartesian coordinates)
+        >>> func_vals = func(atgrid.points)
+        # Compute spherical average spline & evaluate it on a set of (radial) points in [0, \infty)
+        >>> spherical_avg = atgrid.spherical_average(func_vals)
         >>> points = np.arange(0.0, 10.0)
-        >>> evals = spherical_avg(points)  # Should be: e^(-r^2)
+        >>> evals = spherical_avg(points)
+        # the largest error happens at origin because the spline is being extrapolated
+        >>> assert np.all(abs(evals - np.exp(- points ** 2)) < 1.0e-3)
 
         """
         # Integrate f(r, \theta, \phi) sin(\theta) d\theta d\phi by multiplying against its weights

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -503,7 +503,7 @@ class TestAtomGrid(TestCase):
 
         # Test that the spherical average of a Gaussian is itself
         numb_pts = 1000
-        random_rad_pts = np.random.uniform(0.02, 1.5, size=(numb_pts,3))
+        random_rad_pts = np.random.uniform(0.0, 1.5, size=(numb_pts,3))
         spherical_avg2 = spherical_avg(random_rad_pts[:, 0])
         func_vals = func(random_rad_pts)
         assert_allclose(spherical_avg2, func_vals, atol=1e-4)

--- a/src/grid/tests/test_utils.py
+++ b/src/grid/tests/test_utils.py
@@ -92,6 +92,23 @@ class TestUtils(TestCase):
             y = xy * np.sin(sph_coor[:, 1])
             assert_allclose(y, pts[:, 1])
 
+    def test_convert_cart_to_sph_origin(self):
+        """Test convert_cart_sph at origin."""
+        # point at origin
+        pts = np.array([[0.0, 0.0, 0.0]])
+        sph_coor = convert_cart_to_sph(pts, center=None)
+        assert_allclose(sph_coor, 0.0)
+        # point very close to origin
+        pts = np.array([[1.0e-15, 1.0e-15, 1.0e-15]])
+        sph_coor = convert_cart_to_sph(pts, center=None)
+        assert sph_coor[0, 0] < 1.0e-12
+        assert np.all(sph_coor[0, 1:] < 1.0)
+        # point very very close to origin
+        pts = np.array([[1.0e-100, 1.0e-100, 1.0e-100]])
+        sph_coor = convert_cart_to_sph(pts, center=None)
+        assert sph_coor[0, 0] < 1.0e-12
+        assert np.all(sph_coor[0, 1:] < 1.0)
+
     def test_raise_errors(self):
         """Test raise proper errors."""
         with self.assertRaises(ValueError):

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -267,6 +267,8 @@ def convert_cart_to_sph(points, center=None):
     r = np.linalg.norm(relat_pts, axis=-1)
     # polar angle: arccos(z / r)
     phi = np.arccos(relat_pts[:, 2] / r)
+    # fix nan generated when point is [0.0, 0.0, 0.0]
+    phi[r == 0.0] = 0.0
     # azimuthal angle arctan2(y / x)
     theta = np.arctan2(relat_pts[:, 1], relat_pts[:, 0])
     return np.vstack([r, theta, phi]).T


### PR DESCRIPTION
This pull request adds the spherical average of a function in AtomGrid class.  It returns a splines that takes in radial points.

The tests that are included are:
- The spherical average of a Gaussian is itself and its integral (with 4 pi r^2) of the spherical average function is the integral of the Gaussian (pi^1.5)
- The spherical average of a Spherical Harmonic (whose degree is less than the degree of the atom grid) is zero.