### PR TITLE
Update ci.yml to latest version of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           - "3.7"
     steps:
       - name: Setup python for test ${{ matrix.py }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.py }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install tox-gh
         run: python -m pip install tox-gh
       - name: Setup test suite


### PR DESCRIPTION
When merging the last pull request on `iodata` I got an warning message:  

`Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.`

The fix seems to be to upgrade to version 3 of actions and I made the appropriate increment. 
