### PR TITLE
Generalize Some Radial Transformations

### DIFF
--- a/src/grid/tests/test_rtransform.py
+++ b/src/grid/tests/test_rtransform.py
@@ -127,9 +127,11 @@ class TestRTransform(TestCase):
 
     def test_linear_basics(self):
         """Test linear tf."""
-        gd = np.ones(100) * 0
+        gd = np.arange(100)
         rtf = LinearInfiniteRTransform(-0.7, 0.8)
+        print(rtf.transform(gd))
         assert abs(rtf.transform(gd)[0] - -0.7) < 1e-15
+        assert abs(rtf.transform(gd)[-1] - 0.8) < 1e-15
         gd = np.ones(100) * 99
         assert abs(rtf.transform(gd)[0] - 0.8) < 1e-10
         self.check_consistency(rtf)

--- a/src/grid/tests/test_rtransform.py
+++ b/src/grid/tests/test_rtransform.py
@@ -132,6 +132,7 @@ class TestRTransform(TestCase):
         print(rtf.transform(gd))
         assert abs(rtf.transform(gd)[0] - -0.7) < 1e-15
         assert abs(rtf.transform(gd)[-1] - 0.8) < 1e-15
+        rtf = LinearInfiniteRTransform(-0.7, 0.8)
         gd = np.ones(100) * 99
         assert abs(rtf.transform(gd)[0] - 0.8) < 1e-10
         self.check_consistency(rtf)

--- a/src/grid/tests/test_rtransform.py
+++ b/src/grid/tests/test_rtransform.py
@@ -141,11 +141,12 @@ class TestRTransform(TestCase):
 
     def test_exp_basics(self):
         """Test exponential tf."""
-        rtf = ExpRTransform(0.1, 1e1)
-        gd = np.ones(100) * 0
-        assert abs(rtf.transform(gd)[0] - 0.1) < 1e-15
+        rtf = ExpRTransform(0.1, 10.0)
+        gd = np.arange(100)
+        assert abs(rtf.transform(gd)[0] - 0.1) < 1e-10
+        assert abs(rtf.transform(gd)[-1] - 10.0) < 1e-10
         gd = np.ones(100) * 99
-        assert abs(rtf.transform(gd)[0] - 1e1) < 1e-10
+        assert abs(rtf.transform(gd)[0] - 10.0) < 1e-10
         self.check_consistency(rtf)
         self.check_deriv(rtf)
         # check_chop(rtf)
@@ -160,9 +161,10 @@ class TestRTransform(TestCase):
         """Test power tf."""
         cases = self.get_power_cases()
         for rmin, rmax in cases:
-            gd = np.ones(100) * 99
+            gd = np.arange(100)
             rtf = PowerRTransform(rmin, rmax)
-            assert abs(rtf.transform(gd)[0] - rmax) < 1e-9
+            assert abs(rtf.transform(gd)[-1] - rmax) < 1e-9
+            assert abs(rtf.transform(gd)[0] - rmin) < 1e-9
             self.check_consistency(rtf)
             self.check_deriv(rtf)
             # check_chop(rtf)


### PR DESCRIPTION
Generalize radial transformations specific to HortonGrids/UniformInteger Grids. Specific to issue #143. 

The following grids were generalized to work over any grid:
- ExpRTransform
- LinearInfiniteRTransform
- PowerRTransform

The following grid wasn't generalized because it requires some assumptions on the parameters and is very heavy parameter fiddling
- HyperbolicRTransform.