### PR TITLE
Fix raising warnings and pytest depreciation (#208)

### DIFF
--- a/src/grid/cubic.py
+++ b/src/grid/cubic.py
@@ -102,7 +102,7 @@ class _HyperRectangleGrid(Grid):
         return x, y
 
     def interpolate(self, points, values, use_log=False, nu_x=0, nu_y=0, nu_z=0, method="cubic"):
-        r"""Interpolate function value at a given point(s).
+        r"""Interpolate function and its derivatives on cubic grid.
 
         Only implemented in three-dimensions.
 

--- a/src/grid/cubic.py
+++ b/src/grid/cubic.py
@@ -102,7 +102,7 @@ class _HyperRectangleGrid(Grid):
         return x, y
 
     def interpolate(self, points, values, use_log=False, nu_x=0, nu_y=0, nu_z=0, method="cubic"):
-        r"""Interpolate function value at a given point.
+        r"""Interpolate function value at a given point(s).
 
         Only implemented in three-dimensions.
 
@@ -110,7 +110,8 @@ class _HyperRectangleGrid(Grid):
         ----------
         points : np.ndarray, shape (M, 3)
             The 3D Cartesian coordinates of :math:`M` points in :math:`\mathbb{R}^3` for which
-            the interpolant (i.e., the interpolated function) is evaluated.
+            the interpolant (i.e., the interpolated function) is evaluated. If
+            method="cubic", then M must be equal to one.
         values : np.ndarray, shape (N,)
             Function values at each of the :math:`N` grid points.
         use_log : bool, optional
@@ -237,15 +238,22 @@ class _HyperRectangleGrid(Grid):
                     deriv_var = nu_z
                 # Sympy symbols and dictionary of symbols pointing to the derivative values
                 sympy_symbols = symbols("x:" + str(deriv_var))
-                symbol_values = {"x" + str(i): float(derivs[i]) for i in range(0, deriv_var)}
-                return interpolated * float(
-                    sum(
-                        [
-                            bell(deriv_var, i, sympy_symbols).evalf(subs=symbol_values)
-                            for i in range(1, deriv_var + 1)
-                        ]
+                # This interpolation only works on singular points and thus we can safely
+                #   assuming derivs=[[0], [1]] is a list of list of single points.
+                bell_derivs = []
+                for j in range(0, len(points)):
+                    symbol_values = {"x" + str(i): float(derivs[i][j]) for i in range(0, deriv_var)}
+                    bell_derivs.append(
+                        float(
+                            sum(
+                                [
+                                    bell(deriv_var, i, sympy_symbols).evalf(subs=symbol_values)
+                                    for i in range(1, deriv_var + 1)
+                                ]
+                            )
+                        )
                     )
-                )
+                return interpolated * np.array(bell_derivs)
             else:
                 raise NotImplementedError(
                     "Taking mixed derivative while applying the logarithm is not supported."

--- a/src/grid/poisson.py
+++ b/src/grid/poisson.py
@@ -323,9 +323,10 @@ def _solve_poisson_bvp_atomgrid(
     def interpolate(points):
         # Need atomgrid to center the points to the atomic grid, then convert to spherical.
         r_pts, theta, phi = atomgrid.convert_cartesian_to_spherical(points).T
-        r_values = np.array([spline(r_pts) / r_pts for spline in splines])
-        # Since spline(r=0) = 0, then set points to zero there.
-        r_values[:, np.abs(r_pts) < 1e-300] = 0.0
+        with np.errstate(divide='ignore'):
+            r_values = np.array([spline(r_pts) / r_pts for spline in splines])
+            # Since spline(r=0) = 0, then set points to zero there.
+            r_values[:, np.abs(r_pts) < 1e-300] = 0.0
         r_sph_harm = generate_real_spherical_harmonics(atomgrid.l_max // 2, theta, phi)
         return np.einsum("ij, ij -> j", r_values, r_sph_harm)
 

--- a/src/grid/poisson.py
+++ b/src/grid/poisson.py
@@ -323,7 +323,7 @@ def _solve_poisson_bvp_atomgrid(
     def interpolate(points):
         # Need atomgrid to center the points to the atomic grid, then convert to spherical.
         r_pts, theta, phi = atomgrid.convert_cartesian_to_spherical(points).T
-        with np.errstate(divide='ignore'):
+        with np.errstate(divide="ignore"):
             r_values = np.array([spline(r_pts) / r_pts for spline in splines])
             # Since spline(r=0) = 0, then set points to zero there.
             r_values[:, np.abs(r_pts) < 1e-300] = 0.0

--- a/src/grid/tests/test_angular.py
+++ b/src/grid/tests/test_angular.py
@@ -190,6 +190,29 @@ def test_orthogonality_of_spherical_harmonic_up_to_degree_three(use_spherical):
                         assert np.abs(integral - 1.0) < 1e-8
 
 
+def test_orthogonality_of_spherical_harmonic_at_high_degrees():
+    r"""Test orthogonality of spherical harmonic is accurate at very high degrees."""
+    degree = 88 * 2
+    grid = AngularGrid(degree=degree, use_spherical=True)
+    # Concert to spherical coordinates from Cartesian.
+    r = np.linalg.norm(grid.points, axis=1)
+    phi = np.arccos(grid.points[:, 2] / r)
+    theta = np.arctan2(grid.points[:, 1], grid.points[:, 0])
+    half_l = degree // 2
+    sph_harm = generate_real_spherical_harmonics(half_l, theta, phi)
+    for l_deg in range(half_l - 1, half_l):
+        for m_ord in [0] + [j for i in [[i, -i] for i in range(1, l_deg)] for j in i]:
+            for l2 in range(half_l - 1, half_l):
+                for m2 in [0] + [j for i in [[i, -i] for i in range(1, l2)] for j in i]:
+                    sph_harm_one = sph_harm[l_deg**2 : (l_deg + 1) ** 2, :]
+                    sph_harm_two = sph_harm[l2**2 : (l2 + 1) ** 2, :]
+                    integral = grid.integrate(sph_harm_one[m_ord, :] * sph_harm_two[m2, :])
+                    if l2 != l_deg or m2 != m_ord:
+                        assert np.abs(integral) < 1e-8
+                    else:
+                        assert np.abs(integral - 1.0) < 1e-8
+
+
 def test_that_symmetric_spherical_design_is_symmetric():
     r"""Test the sum of all points on the sphere is zero."""
     for degree in SPHERICAL_DEGREES.keys():

--- a/src/grid/tests/test_angular.py
+++ b/src/grid/tests/test_angular.py
@@ -60,14 +60,15 @@ class TestLebedev(TestCase):
         """Test cache behavior of spherical grid."""
         degrees = np.random.randint(1, 100, 50)
         LEBEDEV_CACHE.clear()
-        for i in degrees:
-            AngularGrid(degree=i, cache=False)
-        assert len(LEBEDEV_CACHE) == 0
-
-        for i in degrees:
-            AngularGrid(degree=i)
-            ref_d = AngularGrid._get_size_and_degree(degree=i)[0]
-            assert ref_d in LEBEDEV_CACHE
+        with pytest.warns(UserWarning, match="Lebedev weights are negative*"):
+            for i in degrees:
+                AngularGrid(degree=i, cache=False)
+            assert len(LEBEDEV_CACHE) == 0
+        with pytest.warns(UserWarning, match="Lebedev weights are negative*"):
+            for i in degrees:
+                AngularGrid(degree=i)
+                ref_d = AngularGrid._get_size_and_degree(degree=i)[0]
+                assert ref_d in LEBEDEV_CACHE
 
     def test_convert_lebedev_sizes_to_degrees(self):
         """Test size to degree conversion."""

--- a/src/grid/tests/test_angular.py
+++ b/src/grid/tests/test_angular.py
@@ -59,6 +59,8 @@ class TestLebedev(TestCase):
     def test_lebedev_cache(self):
         """Test cache behavior of spherical grid."""
         degrees = np.random.randint(1, 100, 50)
+        # Add 13 so that the warning is guaranteed to happen so pytest warning works.
+        degrees = np.append(degrees, [13])
         LEBEDEV_CACHE.clear()
         with pytest.warns(UserWarning, match="Lebedev weights are negative*"):
             for i in degrees:

--- a/src/grid/tests/test_angular.py
+++ b/src/grid/tests/test_angular.py
@@ -128,17 +128,17 @@ class TestLebedev(TestCase):
             AngularGrid(pts, wts, size=14)
 
 
-@pytest.mark.parametrize("degree", [5, 10])
+@pytest.mark.parametrize("degree", [5, 10, 100])
 @pytest.mark.parametrize("use_spherical", [False, True])
 def test_integration_of_spherical_harmonic_up_to_degree(degree, use_spherical):
-    r"""Test integration of spherical harmonic up to degree 10 is accurate."""
+    r"""Test integration of spherical harmonic is accurate."""
     grid = AngularGrid(degree=degree, use_spherical=use_spherical)
     # Concert to spherical coordinates from Cartesian.
     r = np.linalg.norm(grid.points, axis=1)
     phi = np.arccos(grid.points[:, 2] / r)
     theta = np.arctan2(grid.points[:, 1], grid.points[:, 0])
     # Generate All Spherical Harmonics Up To Degree = 10
-    #   Returns a three dimensional array where [order m, degree l, points]
+    #   Returns a three-dimensional array where [order m, degree l, points]
     sph_harm = generate_real_spherical_harmonics(degree, theta, phi)
     for l_deg in range(0, degree):
         for m_ord in range(-l_deg, l_deg):

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -98,6 +98,7 @@ class TestAtomGrid:
         assert_allclose(ag_ob.rgrid.points, rgrid.points)
         assert_allclose(ag_ob.rgrid.weights, rgrid.weights)
 
+    @pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")
     def test_from_predefined(self):
         """Test grid construction with predefined grid."""
         # test coarse grid
@@ -327,6 +328,7 @@ class TestAtomGrid:
         phi = np.arccos(ref_coor[2] / r)
         assert_allclose(np.array([r, theta, phi]).reshape(-1, 3), calc_sph)
 
+    @pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")
     @pytest.mark.parametrize("use_spherical", [False, True])
     def test_spherical_complete(self, use_spherical):
         """Test atomic grid consistence for spherical integral."""
@@ -725,6 +727,7 @@ class TestAtomGrid:
         spherical_avg2 = spherical_avg(random_rad_pts[:, 0])
         assert_allclose(spherical_avg2, 0.0, atol=1e-4)
 
+    @pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")
     @pytest.mark.parametrize("use_spherical", [False, True])
     def test_interpolate_and_its_derivatives_on_polynomial(self, use_spherical):
         """Test interpolation of derivative of polynomial function."""

--- a/src/grid/tests/test_atomgrid.py
+++ b/src/grid/tests/test_atomgrid.py
@@ -633,6 +633,7 @@ class TestAtomGrid:
                 values[atgrid.indices[i] : atgrid.indices[i + 1]],
             )
 
+    @pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")
     def test_cubicspline_and_interp(self):
         """Test cubicspline interpolation values."""
         odg = OneDGrid(np.arange(10) + 1, np.ones(10), (0, np.inf))

--- a/src/grid/tests/test_becke.py
+++ b/src/grid/tests/test_becke.py
@@ -24,6 +24,7 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from grid.becke import BeckeWeights
 
@@ -135,10 +136,17 @@ class TestBecke(TestCase):
             pts[:, 1:] += np.random.rand(10, 2)
 
             becke = BeckeWeights(order=3)
-            wts = becke.generate_weights(pts, centers, nums, pt_ind=[0, 5, 10])
-            assert_allclose(wts, 0.5)
-            wts = becke.compute_weights(pts, centers, nums, pt_ind=[0, 5, 10])
-            assert_allclose(wts, 0.5)
+            # Make sure a warning was raised, since covalent radii are not defined
+            with pytest.warns(
+                UserWarning, match="Covalent radii for the following atom numbers [\\d+]*"
+            ):
+                wts = becke.generate_weights(pts, centers, nums, pt_ind=[0, 5, 10])
+                assert_allclose(wts, 0.5)
+            with pytest.warns(
+                UserWarning, match="Covalent radii for the following atom numbers [\\d+]*"
+            ):
+                wts = becke.compute_weights(pts, centers, nums, pt_ind=[0, 5, 10])
+                assert_allclose(wts, 0.5)
 
     def test_raise_errors(self):
         """Test errors raise."""

--- a/src/grid/tests/test_becke.py
+++ b/src/grid/tests/test_becke.py
@@ -23,8 +23,8 @@
 from unittest import TestCase
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from grid.becke import BeckeWeights
 

--- a/src/grid/tests/test_cubic.py
+++ b/src/grid/tests/test_cubic.py
@@ -243,8 +243,11 @@ class TestTensor1DGrids(TestCase):
             return np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0)
 
         def derivative_wrt_one_var(points, i_var_deriv):
-            return (np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0) *
-                    points[:, i_var_deriv] * (-3 * 2.0))
+            return (
+                np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0)
+                * points[:, i_var_deriv]
+                * (-3 * 2.0)
+            )
 
         def derivative_second_x(points):
             expon = np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0)
@@ -266,9 +269,7 @@ class TestTensor1DGrids(TestCase):
         assert_allclose(interpolated, derivative_wrt_one_var(pts, 2), rtol=1e-4)
 
         # Test taking second-derivative in x-direction
-        interpolated = cubic.interpolate(
-            pts, gaussian_pts, use_log=True, nu_x=2, nu_y=0, nu_z=0
-        )
+        interpolated = cubic.interpolate(pts, gaussian_pts, use_log=True, nu_x=2, nu_y=0, nu_z=0)
         assert_allclose(interpolated, derivative_second_x(pts), rtol=1e-4)
 
         # Test raises error

--- a/src/grid/tests/test_cubic.py
+++ b/src/grid/tests/test_cubic.py
@@ -242,38 +242,38 @@ class TestTensor1DGrids(TestCase):
         def gaussian(points):
             return np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0)
 
-        def derivative_wrt_one_var(point, i_var_deriv):
-            return np.exp(-3 * np.linalg.norm(point) ** 2.0) * point[i_var_deriv] * (-3 * 2.0)
+        def derivative_wrt_one_var(points, i_var_deriv):
+            return (np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0) *
+                    points[:, i_var_deriv] * (-3 * 2.0))
 
-        def derivative_second_x(point):
-            return np.exp(-3 * np.linalg.norm(point) ** 2.0) * point[0] ** 2.0 * (
-                -3 * 2.0
-            ) ** 2.0 + np.exp(-3 * np.linalg.norm(point) ** 2.0) * (-3 * 2.0)
+        def derivative_second_x(points):
+            expon = np.exp(-3 * np.linalg.norm(points, axis=1) ** 2.0)
+            return expon * points[:, 0] ** 2.0 * (-3 * 2.0) ** 2.0 + expon * (-3 * 2.0)
 
         gaussian_pts = gaussian(cubic.points)
 
-        pt = np.random.uniform(-0.5, 0.5, (3,))
+        pts = np.random.uniform(-0.5, 0.5, (10, 3))
         # Test taking derivative in x-direction
-        interpolated = cubic.interpolate(pt[np.newaxis, :], gaussian_pts, use_log=True, nu_x=1)
-        assert_allclose(interpolated, derivative_wrt_one_var(pt, 0), rtol=1e-4)
+        interpolated = cubic.interpolate(pts, gaussian_pts, use_log=True, nu_x=1)
+        assert_allclose(interpolated, derivative_wrt_one_var(pts, 0), rtol=1e-4)
 
         # Test taking derivative in y-direction
-        interpolated = cubic.interpolate(pt[np.newaxis, :], gaussian_pts, use_log=True, nu_y=1)
-        assert_allclose(interpolated, derivative_wrt_one_var(pt, 1), rtol=1e-4)
+        interpolated = cubic.interpolate(pts, gaussian_pts, use_log=True, nu_y=1)
+        assert_allclose(interpolated, derivative_wrt_one_var(pts, 1), rtol=1e-4)
 
         # Test taking derivative in z-direction
-        interpolated = cubic.interpolate(pt[np.newaxis, :], gaussian_pts, use_log=True, nu_z=1)
-        assert_allclose(interpolated, derivative_wrt_one_var(pt, 2), rtol=1e-4)
+        interpolated = cubic.interpolate(pts, gaussian_pts, use_log=True, nu_z=1)
+        assert_allclose(interpolated, derivative_wrt_one_var(pts, 2), rtol=1e-4)
 
         # Test taking second-derivative in x-direction
         interpolated = cubic.interpolate(
-            pt[np.newaxis, :], gaussian_pts, use_log=True, nu_x=2, nu_y=0, nu_z=0
+            pts, gaussian_pts, use_log=True, nu_x=2, nu_y=0, nu_z=0
         )
-        assert_allclose(interpolated, derivative_second_x(pt), rtol=1e-4)
+        assert_allclose(interpolated, derivative_second_x(pts), rtol=1e-4)
 
         # Test raises error
         with self.assertRaises(NotImplementedError):
-            cubic.interpolate(pt[np.newaxis, :], gaussian_pts, use_log=True, nu_x=2, nu_y=2)
+            cubic.interpolate(pts, gaussian_pts, use_log=True, nu_x=2, nu_y=2)
 
     def test_integration_of_gaussian(self):
         r"""Test integration of a rapidly-decreasing Gaussian."""

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -36,6 +36,7 @@ from grid.rtransform import ExpRTransform, LinearFiniteRTransform
 # Ignore angular/Lebedev grid warnings where the weights are negative:
 pytestmark = pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")
 
+
 class TestMolGrid(TestCase):
     """MolGrid test class."""
 

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
+import pytest
 
 from grid.atomgrid import AtomGrid, _get_rgrid_size
 from grid.basegrid import LocalGrid
@@ -31,6 +32,9 @@ from grid.molgrid import MolGrid
 from grid.onedgrid import GaussLaguerre, Trapezoidal, UniformInteger
 from grid.rtransform import ExpRTransform, LinearFiniteRTransform
 
+
+# Ignore angular/Lebedev grid warnings where the weights are negative:
+pytestmark = pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")
 
 class TestMolGrid(TestCase):
     """MolGrid test class."""

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -21,8 +21,8 @@
 from unittest import TestCase
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
+from numpy.testing import assert_allclose, assert_almost_equal
 
 from grid.atomgrid import AtomGrid, _get_rgrid_size
 from grid.basegrid import LocalGrid
@@ -31,7 +31,6 @@ from grid.hirshfeld import HirshfeldWeights
 from grid.molgrid import MolGrid
 from grid.onedgrid import GaussLaguerre, Trapezoidal, UniformInteger
 from grid.rtransform import ExpRTransform, LinearFiniteRTransform
-
 
 # Ignore angular/Lebedev grid warnings where the weights are negative:
 pytestmark = pytest.mark.filterwarnings("ignore:Lebedev weights are negative which can*")

--- a/src/grid/tests/test_ode.py
+++ b/src/grid/tests/test_ode.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal, assert_raises
 from scipy.integrate import solve_bvp
+import warnings
 
 from grid.ode import (
     _derivative_transformation_matrix,
@@ -384,19 +385,26 @@ def test_error_raises_for_solve_ode_bvp():
     x = np.linspace(-0.999, 0.999, 20)
 
     def fx(x):
-        return 1 / x**2
+        # Ignore any warnings from divide by zero
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return 1 / x**2
 
     coeffs = [-1, -2, 1]
     bd_cond = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0)]
-    # Test the error that the number of boundary conditions should be equal to order.
-    assert_raises(ValueError, solve_ode_bvp, x, fx, coeffs, bd_cond[3:])
-    assert_raises(ValueError, solve_ode_bvp, x, fx, coeffs, bd_cond)
-    test_coeff = [1, 2, 3, 4, 5]
-    assert_raises(ValueError, solve_ode_bvp, x, fx, test_coeff, bd_cond)
 
-    test_coeff = [1, 2, 3, 3]
-    tf = BeckeRTransform(0.1, 1)
-    assert_raises(ValueError, solve_ode_bvp, x, fx, test_coeff, bd_cond[:3], tf)
+    # Ignore the SciPy warning from divide by zero, since this is an assertion test-case
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # Test the error that the number of boundary conditions should be equal to order.
+        assert_raises(ValueError, solve_ode_bvp, x, fx, coeffs, bd_cond[3:])
+        assert_raises(ValueError, solve_ode_bvp, x, fx, coeffs, bd_cond)
+        test_coeff = [1, 2, 3, 4, 5]
+        assert_raises(ValueError, solve_ode_bvp, x, fx, test_coeff, bd_cond)
+
+        test_coeff = [1, 2, 3, 3]
+        tf = BeckeRTransform(0.1, 1)
+        assert_raises(ValueError, solve_ode_bvp, x, fx, test_coeff, bd_cond[:3], tf)
 
 
 def test_construct_coeffs_of_ode_over_mesh():

--- a/src/grid/tests/test_ode.py
+++ b/src/grid/tests/test_ode.py
@@ -18,13 +18,13 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """ODE test module."""
+import warnings
 from numbers import Number
 
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal, assert_raises
 from scipy.integrate import solve_bvp
-import warnings
 
 from grid.ode import (
     _derivative_transformation_matrix,

--- a/src/grid/tests/test_onedgrid.py
+++ b/src/grid/tests/test_onedgrid.py
@@ -23,6 +23,7 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
+import pytest
 from scipy.special import roots_chebyu, roots_legendre
 
 from grid.onedgrid import (
@@ -248,23 +249,32 @@ class TestOneDGrid(TestCase):
         with self.assertRaises(ValueError):
             FejerSecond(-10)
         with self.assertRaises(ValueError):
-            ExpSinh(11, -0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                ExpSinh(11, -0.1)
         with self.assertRaises(ValueError):
-            ExpSinh(-11, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                ExpSinh(-11, 0.1)
         with self.assertRaises(ValueError):
-            ExpSinh(10, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                ExpSinh(10, 0.1)
         with self.assertRaises(ValueError):
-            LogExpSinh(11, -0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                LogExpSinh(11, -0.1)
         with self.assertRaises(ValueError):
-            LogExpSinh(-11, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                LogExpSinh(-11, 0.1)
         with self.assertRaises(ValueError):
-            LogExpSinh(10, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                LogExpSinh(10, 0.1)
         with self.assertRaises(ValueError):
-            ExpExp(11, -0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                ExpExp(11, -0.1)
         with self.assertRaises(ValueError):
-            ExpExp(-11, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                ExpExp(-11, 0.1)
         with self.assertRaises(ValueError):
-            ExpExp(10, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                ExpExp(10, 0.1)
         with self.assertRaises(ValueError):
             SingleTanh(11, -0.1)
         with self.assertRaises(ValueError):
@@ -272,17 +282,23 @@ class TestOneDGrid(TestCase):
         with self.assertRaises(ValueError):
             SingleTanh(10, 0.1)
         with self.assertRaises(ValueError):
-            SingleExp(11, -0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                SingleExp(11, -0.1)
         with self.assertRaises(ValueError):
-            SingleExp(-11, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                SingleExp(-11, 0.1)
         with self.assertRaises(ValueError):
-            SingleExp(10, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                SingleExp(10, 0.1)
         with self.assertRaises(ValueError):
-            SingleArcSinhExp(11, -0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                SingleArcSinhExp(11, -0.1)
         with self.assertRaises(ValueError):
-            SingleArcSinhExp(-11, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                SingleArcSinhExp(-11, 0.1)
         with self.assertRaises(ValueError):
-            SingleArcSinhExp(10, 0.1)
+            with pytest.warns(UserWarning, match="Using this quadrature require *"):
+                SingleArcSinhExp(10, 0.1)
 
     @staticmethod
     def helper_gaussian(x):
@@ -606,7 +622,8 @@ class TestOneDGrid(TestCase):
 
     def test_ExpSinh(self):
         """Test for ExpSinh rule."""
-        grid = ExpSinh(11, 0.1)
+        with pytest.warns(UserWarning, match="Using this quadrature require *"):
+            grid = ExpSinh(11, 0.1)
 
         k = np.arange(-5, 6)
         points = np.exp(np.pi * np.sinh(k * 0.1) / 2)
@@ -617,7 +634,8 @@ class TestOneDGrid(TestCase):
 
     def test_LogExpSinh(self):
         """Test for LogExpSinh rule."""
-        grid = LogExpSinh(11, 0.1)
+        with pytest.warns(UserWarning, match="Using this quadrature require *"):
+            grid = LogExpSinh(11, 0.1)
 
         k = np.arange(-5, 6)
         points = np.log(np.exp(np.pi * np.sinh(k * 0.1) / 2) + 1)
@@ -629,7 +647,9 @@ class TestOneDGrid(TestCase):
 
     def test_ExpExp(self):
         """Test for ExpExp rule."""
-        grid = ExpExp(11, 0.1)
+        # Test that Userwarning was raised when using ExpExp
+        with pytest.warns(UserWarning, match="Using this quadrature require *"):
+            grid = ExpExp(11, 0.1)
 
         k = np.arange(-5, 6)
         points = np.exp(k * 0.1) * np.exp(-np.exp(-k * 0.1))
@@ -651,7 +671,8 @@ class TestOneDGrid(TestCase):
 
     def test_SingleExp(self):
         """Test for Single Exp rule."""
-        grid = SingleExp(11, 0.1)
+        with pytest.warns(UserWarning, match="Using this quadrature require *"):
+            grid = SingleExp(11, 0.1)
 
         k = np.arange(-5, 6)
         points = np.exp(k * 0.1)
@@ -662,7 +683,8 @@ class TestOneDGrid(TestCase):
 
     def test_SingleArcSinhExp(self):
         """Test for SingleArcSinhExp rule."""
-        grid = SingleArcSinhExp(11, 0.1)
+        with pytest.warns(UserWarning, match="Using this quadrature require *"):
+            grid = SingleArcSinhExp(11, 0.1)
 
         k = np.arange(-5, 6)
         points = np.arcsinh(np.exp(k * 0.1))

--- a/src/grid/tests/test_onedgrid.py
+++ b/src/grid/tests/test_onedgrid.py
@@ -22,8 +22,8 @@
 from unittest import TestCase
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
+from numpy.testing import assert_allclose, assert_almost_equal
 from scipy.special import roots_chebyu, roots_legendre
 
 from grid.onedgrid import (

--- a/src/grid/tests/test_periodicgrid.py
+++ b/src/grid/tests/test_periodicgrid.py
@@ -18,10 +18,11 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """PeriodicGrid tests file."""
+import warnings
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-import warnings
 
 from grid.basegrid import Grid
 from grid.periodicgrid import PeriodicGrid, PeriodicGridWarning

--- a/src/grid/tests/test_periodicgrid.py
+++ b/src/grid/tests/test_periodicgrid.py
@@ -21,6 +21,7 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+import warnings
 
 from grid.basegrid import Grid
 from grid.periodicgrid import PeriodicGrid, PeriodicGridWarning
@@ -135,7 +136,7 @@ def setup_equidistant_grid(origin, realvecs, npts):
     )
     # The weights take into account the Jacobian of the affine transformation
     # from fractional to Cartesian grid points.
-    npt_total = np.product(npts)
+    npt_total = np.prod(npts)
     weights = np.full(npt_total, abs(np.linalg.det(realvecs)) / npt_total)
     return PeriodicGrid(points, weights, realvecs)
 
@@ -282,16 +283,26 @@ class PeriodicGridTester:
 
     """
 
-    def setup(self):
+    def setup_method(self):
         """Initialize an unwrapped and a wrapped version of the grid."""
         self.define_reference_data()
-        with pytest.warns(None if self._ref_realvecs is None else PeriodicGridWarning):
+        with warnings.catch_warnings(record=True) as w:
+            # warnings.simplefilter("error", PeriodicGridWarning)
+            warnings.simplefilter("always")
             self.grid = PeriodicGrid(self._ref_points, self._ref_weights, self._ref_realvecs)
-        with pytest.warns(None) as record:
+
+            # Test that if _ref_realvecs is not None and warning was raised
+            #   then it was a PeriodicGridWarnings
+            if self._ref_realvecs is not None:
+                assert len(w) == 1  # assert there was only one warning
+                # assert that the warning was PeriodicGridWarning
+                assert issubclass(w[-1].category, PeriodicGridWarning)
+
+        with warnings.catch_warnings(record=True) as record:
             self.wrapped_grid = PeriodicGrid(
                 self._ref_points, self._ref_weights, self._ref_realvecs, True
             )
-            assert len(record) == 0
+            assert len(record) == 0  # Assert no warning was raised
 
     def define_reference_data(self):
         """Define reference data for the test."""
@@ -335,12 +346,20 @@ class PeriodicGridTester:
         assert_allclose(grid_index.frac_intvls, ref_grid_index.frac_intvls)
         assert isinstance(grid_index, PeriodicGrid)
         # test slice
-        with pytest.warns(None if self._ref_realvecs is None else PeriodicGridWarning):
+        with warnings.catch_warnings(record=True) as w:
             ref_grid_slice = PeriodicGrid(
                 self._ref_points[:15], self._ref_weights[:15], self._ref_realvecs
             )
-        with pytest.warns(None if self._ref_realvecs is None else PeriodicGridWarning):
+            if self._ref_realvecs is not None:
+                assert len(w) == 1
+                # Assert the warning was PeriodicGrid Warning
+                assert issubclass(w[-1].category, PeriodicGridWarning)
+        with warnings.catch_warnings(record=True) as w:
             grid_slice = self.grid[:15]
+            if self._ref_realvecs is not None:
+                assert len(w) == 1  # assert only one warning was raised
+                # Assert the warning was PeriodicGrid Warning
+                assert issubclass(w[-1].category, PeriodicGridWarning)
         assert_allclose(grid_slice.points, ref_grid_slice.points)
         assert_allclose(grid_slice.weights, ref_grid_slice.weights)
         assert_allclose(grid_slice.realvecs, self.grid.realvecs)

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -83,7 +83,7 @@ def poisson_solution_to_charge_distribution(x, alpha=0.1, centers=None):
     for cent in centers:
         r_PC = np.linalg.norm(x - cent, axis=1)
         # Ignore divide by zero and nan
-        with np.errstate(divide='ignore', invalid="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):
             desired = erf(np.sqrt(alpha) * r_PC) / r_PC
             desired[r_PC == 0.0] = 0.0
         result += desired

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -82,8 +82,10 @@ def poisson_solution_to_charge_distribution(x, alpha=0.1, centers=None):
     result = np.zeros(len(x))
     for cent in centers:
         r_PC = np.linalg.norm(x - cent, axis=1)
-        desired = erf(np.sqrt(alpha) * r_PC) / r_PC
-        desired[r_PC == 0.0] = 0.0
+        # Ignore divide by zero and nan
+        with np.errstate(divide='ignore', invalid="ignore"):
+            desired = erf(np.sqrt(alpha) * r_PC) / r_PC
+            desired[r_PC == 0.0] = 0.0
         result += desired
     return result
 

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -36,6 +36,10 @@ from grid.rtransform import (
 )
 from grid.utils import convert_cart_to_sph, generate_real_spherical_harmonics
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The coefficient of the leading Kth term is zero at some point"
+)
+
 
 def zero_func(pts, centers=None):
     """Zero function for test."""

--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -169,6 +169,10 @@ def test_interpolation_of_laplacian_with_unit_charge_distribution():
     assert_allclose(-4.0 * np.pi * charge_distribution(atgrid.points), true, atol=1e-4, rtol=1e-7)
 
 
+# Ignore scipy/bvp warning
+@pytest.mark.filterwarnings(
+    "ignore:(divide by zero encountered in divide|invalid value encountered in divide)"
+)
 @pytest.mark.parametrize(
     "oned, tf, remove_large_pts, centers",
     [

--- a/src/grid/tests/test_utils.py
+++ b/src/grid/tests/test_utils.py
@@ -82,7 +82,7 @@ class TestUtils(TestCase):
 
     def test_generate_real_spherical_is_accurate(self):
         r"""Test generated real spherical harmonic up to degree 3 is accurate."""
-        numb_pts = 100
+        numb_pts = 1000
         pts = np.random.uniform(-1.0, 1.0, size=(numb_pts, 3))
         sph_pts = convert_cart_to_sph(pts)
         r, theta, phi = sph_pts[:, 0], sph_pts[:, 1], sph_pts[:, 2]
@@ -94,6 +94,27 @@ class TestUtils(TestCase):
         # Test l=1, m=1, m=0
         assert_allclose(sph_h[2, :], np.sqrt(3.0 / (4.0 * np.pi)) * pts[:, 0] / r)
         assert_allclose(sph_h[3, :], np.sqrt(3.0 / (4.0 * np.pi)) * pts[:, 1] / r)
+        # Test l=2, m=0
+        assert_allclose(
+            sph_h[4, :],
+            np.sqrt(5.0 / (16.0 * np.pi)) * (3.0 * pts[:, 2]**2.0 - r**2.0) / r**2.0
+        )
+        # Test l=2, m=1, -1
+        assert_allclose(
+            sph_h[5, :], np.sqrt(15.0 / (4.0 * np.pi)) * (pts[:, 0] * pts[:, 2]) / r**2.0
+        )
+        assert_allclose(
+            sph_h[6, :], np.sqrt(15.0 / (4.0 * np.pi)) * (pts[:, 1] * pts[:, 2]) / r**2.0
+        )
+        # Test l=2, m=2, -2
+        assert_allclose(
+            sph_h[7, :],
+            np.sqrt(15.0 / (16.0 * np.pi)) * (pts[:, 0]**2.0 - pts[:, 1]**2.0) / r**2.0
+        )
+        assert_allclose(
+            sph_h[8, :],
+            np.sqrt(15.0 / (4.0 * np.pi)) * (pts[:, 0] * pts[:, 1]) / r**2.0
+        )
 
     def test_generate_real_spherical_is_orthonormal(self):
         """Test generated real spherical harmonics is an orthonormal set."""
@@ -244,7 +265,8 @@ def test_derivative_of_spherical_harmonics_with_finite_difference(numb_pts, max_
     assert_almost_equal(actual_answer[1, :], deriv_phi, decimal=3)
 
 
-@pytest.mark.parametrize("numb_pts, max_degree", [[5, 70], [1000, 4], [5000, 2], [100, 15]])
+@pytest.mark.parametrize("numb_pts, max_degree",
+                         [[20, 70], [1000, 10], [5000, 7], [100, 15]])
 def test_spherical_harmonic_recursion_against_scipy(numb_pts, max_degree):
     r"""Test spherical harmonic recursion against SciPy implementation."""
     theta = np.array([1e-5])

--- a/src/grid/tests/test_utils.py
+++ b/src/grid/tests/test_utils.py
@@ -97,7 +97,7 @@ class TestUtils(TestCase):
         # Test l=2, m=0
         assert_allclose(
             sph_h[4, :],
-            np.sqrt(5.0 / (16.0 * np.pi)) * (3.0 * pts[:, 2]**2.0 - r**2.0) / r**2.0
+            np.sqrt(5.0 / (16.0 * np.pi)) * (3.0 * pts[:, 2] ** 2.0 - r**2.0) / r**2.0,
         )
         # Test l=2, m=1, -1
         assert_allclose(
@@ -109,11 +109,10 @@ class TestUtils(TestCase):
         # Test l=2, m=2, -2
         assert_allclose(
             sph_h[7, :],
-            np.sqrt(15.0 / (16.0 * np.pi)) * (pts[:, 0]**2.0 - pts[:, 1]**2.0) / r**2.0
+            np.sqrt(15.0 / (16.0 * np.pi)) * (pts[:, 0] ** 2.0 - pts[:, 1] ** 2.0) / r**2.0,
         )
         assert_allclose(
-            sph_h[8, :],
-            np.sqrt(15.0 / (4.0 * np.pi)) * (pts[:, 0] * pts[:, 1]) / r**2.0
+            sph_h[8, :], np.sqrt(15.0 / (4.0 * np.pi)) * (pts[:, 0] * pts[:, 1]) / r**2.0
         )
 
     def test_generate_real_spherical_is_orthonormal(self):
@@ -265,8 +264,7 @@ def test_derivative_of_spherical_harmonics_with_finite_difference(numb_pts, max_
     assert_almost_equal(actual_answer[1, :], deriv_phi, decimal=3)
 
 
-@pytest.mark.parametrize("numb_pts, max_degree",
-                         [[20, 70], [1000, 10], [5000, 7], [100, 15]])
+@pytest.mark.parametrize("numb_pts, max_degree", [[20, 70], [1000, 10], [5000, 7], [100, 15]])
 def test_spherical_harmonic_recursion_against_scipy(numb_pts, max_degree):
     r"""Test spherical harmonic recursion against SciPy implementation."""
     theta = np.array([1e-5])

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -692,17 +692,21 @@ def generate_real_spherical_harmonics(l_max: int, theta: np.ndarray, phi: np.nda
             # Compute Y_l^{m} that has cosine(theta) and Y_l^{-m} that has sin(theta)
             if m_ord == 0:
                 # init factorial needed to compute (l-m)!/(l+m)!
-                factorial = (l_deg + 1.0) * l_deg
+                #  Turn the number into an array of longdouble type because of Overflow error
+                #  for high degrees, also add the square-root to mitigate it too
+                factorial = np.sqrt(np.array([(l_deg + 1.0) * l_deg], dtype=np.longdouble))
                 spherical_harm[i_sph, :] = fac_sph(l_deg, m_ord) * p_leg[m_ord, 0]
             else:
                 common_fact = (
-                    (p_leg[m_ord, 0] / np.sqrt(factorial)) * fac_sph(l_deg, m_ord) * np.sqrt(2.0)
+                    (p_leg[m_ord, 0] / factorial[0]) * fac_sph(l_deg, m_ord) * np.sqrt(2.0)
                 )
                 spherical_harm[i_sph, :] = common_fact * np.cos(float(m_ord) * theta)
                 i_sph += 1
                 spherical_harm[i_sph, :] = common_fact * np.sin(float(m_ord) * theta)
                 # Update (l-m)!/(l+m)!
-                factorial *= (float(l_deg) + float(m_ord) + 1.0) * (float(l_deg) - float(m_ord))
+                factorial[0] *= np.sqrt(
+                    (float(l_deg) + float(m_ord) + 1.0) * (float(l_deg) - float(m_ord))
+                )
             i_sph += 1
     return spherical_harm
 

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -558,6 +558,11 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     >>> desired_degree = 2
     >>> spherical_harmonic[(desired_degree)**2: (desired_degree + 1)**2, :]
 
+    Notes
+    -----
+    - SciPy spherical harmonics is known (Jan 30, 2024) to give nans when the degree is large,
+      for our experience, when l >= 86
+
     """
     if l_max < 0:
         raise ValueError(f"lmax needs to be >=0, got l_amx={l_max}")

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -546,9 +546,9 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     -------
     ndarray((l_max + 1)**2, N)
         Value of real spherical harmonics of all orders :math:`m`,and degree
-        :math:`l` spherical harmonics. For each degree, the zeroth order
-        is stored, followed by positive orders then negative orders,ordered as:
-        :math:`(-l, -l + 1, \cdots -1)`.
+        :math:`l` spherical harmonics. For each degree :math:`l`,
+        the orders :math:`m` are in Horton 2 order, i.e.
+        :math:`m=0, 1, -1, 2, -2, \cdots, l, -l`.
 
     Examples
     --------


### PR DESCRIPTION
This pull-requests fixes:
- that pytest removed the option to capture warnings via None, this gives an error when using Python 3.11, see [here](https://github.com/scikit-learn/scikit-learn/issues/22572) and the our pull-request that failed recently #228.  This is heavily used in `test_periodic`, 
- Further `Nose` is used in periodic and is removed by me due to reasons specified by [pytest](https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose).
- Handles all warnings given in all of the tests. This handles issue #208. 
    - For the UserWarnings, I used `pytest.warn(match=)` to make sure the warnings were raised. 
    - In cases, where the warnings were coming from other modules I ignored them use the decorator `@pytest.mark.filterwarnings("ignore:api v1")` to ignore it on the specific test or if I couldn't find out which test were raising a warning I used `pytestmark = pytest.mark.filterwarnings("ignore:...")` to ignore the entire module. This are all specified in the [pytest docs](https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html).
    - Ignore division by zero and nan in our ode or Poisson solver.
- Added vectorization of interpolation derivatives in cubic with a simple fix. This removes the cubic grid warning.
- Fixed the overflow in spherical harmonics by moving the square-root and adding numpy longdouble precision (just in case) and added a test for orthonormality in high dimensions. 