### PR TITLE
Fix colab badges

### DIFF
--- a/examples/Angular_grid.ipynb
+++ b/examples/Angular_grid.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Angular_grid.ipynb\">\n",
-        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Angular_grid.ipynb)"
       ]
     },
     {

--- a/examples/Atom_Grid.ipynb
+++ b/examples/Atom_Grid.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Atom_Grid.ipynb\">\n",
-        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Atom_Grid.ipynb)"
       ]
     },
     {

--- a/examples/Atom_Grid_Construction.ipynb
+++ b/examples/Atom_Grid_Construction.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Atom_Grid_Construction.ipynb\">\n",
-    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Atom_Grid_Construction.ipynb)"
    ]
   },
   {

--- a/examples/Cubic_Grids.ipynb
+++ b/examples/Cubic_Grids.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Cubic_Grids.ipynb\">\n",
-    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Cubic_Grids.ipynb)"
    ]
   },
   {

--- a/examples/Interpolation_and_Poisson.ipynb
+++ b/examples/Interpolation_and_Poisson.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Interpolation_and_Poisson.ipynb\">\n",
-        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Interpolation_and_Poisson.ipynb)"
       ]
     },
     {

--- a/examples/JCP_Paper.ipynb
+++ b/examples/JCP_Paper.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/JCP_Paper.ipynb\">\n",
-    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/JCP_Paper.ipynb)"
    ]
   },
   {

--- a/examples/Molecular_Grid.ipynb
+++ b/examples/Molecular_Grid.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Molecular_Grid.ipynb\">\n",
-        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Molecular_Grid.ipynb)"
       ]
     },
     {

--- a/examples/Molecular_Grid_Construction.ipynb
+++ b/examples/Molecular_Grid_Construction.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Molecular_Grid_Construction.ipynb\">\n",
-    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Molecular_Grid_Construction.ipynb)"
    ]
   },
   {

--- a/examples/Multipole_Moments.ipynb
+++ b/examples/Multipole_Moments.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Multipole_Moments.ipynb\">\n",
-    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Multipole_Moments.ipynb)"
    ]
   },
   {
@@ -194,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/examples/One_dimensional_grids.ipynb
+++ b/examples/One_dimensional_grids.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/One_dimensional_grids.ipynb\">\n",
-        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/One_dimensional_grids.ipynb)"
       ]
     },
     {

--- a/examples/Quickstart.ipynb
+++ b/examples/Quickstart.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/theochem/grid/blob/master/examples/Quickstart.ipynb\">\n",
-        "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-        "</a>"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/theochem/grid/blob/master/examples/Quickstart.ipynb)"
       ]
     },
     {


### PR DESCRIPTION
@Ali-Tehrani HTML-style hyperlinks are not supported by nbsphinx so the google-colab badges don't work when rendered in the readthedocs pages. This PR provides a Fix for that. The solution is taken from https://github.com/QData/TextAttack/issues/244#issuecomment-674476435

One question:
Should we make an "Installation" notebook (separated from the paper notebook) so that we have a "complete" tutorial?