### PR TITLE
Refactor ngrid

### DIFF
--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -64,17 +64,26 @@ class MultiDomainGrid(Grid):
         grid_list : list of Grid
             A list of Grid objects, where each Grid corresponds to a separate argument
             (integration domain) of the function to be integrated.
+
             - At least one grid must be specified.
             - The number of elements in `grid_list` should match the number of arguments
               in the target function.
+
         num_domains : int, optional
             The number of integration domains.
+
             - This parameter is optional and can only be specified when `grid_list` contains
               exactly one grid.
             - It must be a positive integer greater than 1.
             - If specified, the function to integrate is considered to have `num_domains` arguments,
               all defined over the same grid (i.e., the same set of points is used for each
               argument).
+
+        Returns
+        -------
+        MultiDomainGrid
+            A MultiDomainGrid object.
+
         """
         if not isinstance(grid_list, list):
             raise ValueError("The grid list must be defined")
@@ -108,7 +117,8 @@ class MultiDomainGrid(Grid):
     def weights(self):
         """Generator: Combined weights of the multi-dimensional grid.
 
-        Due to the combinatorial nature of the grid, the weights are returned as a generator"""
+        Due to the combinatorial nature of the grid, the weights are returned as a generator
+        """
         if len(self.grid_list) == 1 and self.num_domains is not None:
             # Single grid repeated for multiple domains
             weight_combinations = itertools.product(
@@ -125,7 +135,8 @@ class MultiDomainGrid(Grid):
         """Generator: Combined points of the multi-dimensional grid.
 
         Due to the combinatorial nature of the grid, the points are returned as a generator. Each
-        point is a tuple of the points of the individual grids."""
+        point is a tuple of the points of the individual grids.
+        """
         if len(self.grid_list) == 1 and self.num_domains is not None:
             # Single grid repeated for multiple domains
             points_combinations = itertools.product(
@@ -163,7 +174,6 @@ class MultiDomainGrid(Grid):
         float
             Integral of callable.
         """
-
         integral_value = 0.0
 
         if non_vectorized:

--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -91,6 +91,14 @@ class MultiDomainGrid(Grid):
         self.grid_list = grid_list
         self.num_domains = num_domains
 
+    @property
+    def size(self):
+        """int: the total number of points on the grid."""
+        if len(self.grid_list) == 1 and self.num_domains is not None:
+            return self.grid_list[0].size ** self.num_domains
+        else:
+            return np.prod([grid.size for grid in self.grid_list])
+
     def integrate(self, callable, **call_kwargs):
         r"""
         Integrate callable on the N particle grid.

--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -89,7 +89,12 @@ class MultiDomainGrid(Grid):
                 raise ValueError("grids_num must be a positive integer bigger than 1")
 
         self.grid_list = grid_list
-        self.num_domains = num_domains
+        self._num_domains = num_domains
+
+    @property
+    def num_domains(self):
+        """int: The number of integration domains."""
+        return self._num_domains if self._num_domains is not None else len(self.grid_list)
 
     @property
     def size(self):

--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -115,10 +115,27 @@ class MultiDomainGrid(Grid):
 
     @property
     def weights(self):
-        """Generator: Combined weights of the multi-dimensional grid.
-
-        Due to the combinatorial nature of the grid, the weights are returned as a generator
         """
+        Generator yielding the combined weights of the multi-dimensional grid.
+
+        Because the multi-dimensional grid is formed combinatorially from multiple lower-dimensional
+        grids, the combined weights are returned as a generator for efficiency.
+
+        For a MultiDomainGrid formed from two grids, [(x11, y11), (x12, y12) ... (x1n, y1n)] and
+        [(x21, y21), (x22, y22) ... (x2m, y2m)], the combined weights are calculated as follows:
+        For each combination of points (x1, y1) from the first grid and (x2, y2) from the second
+        2D grid, the combined weight `w` is:
+            w = w1 * w2
+        where `w1` and `w2` are the weights from the individual grids corresponding to
+        (x1, y1) and (x2, y2), respectively.
+
+        Yields
+        ------
+        float
+            The product of the weights from each individual grid that make up a single
+            point in the multi-dimensional grid.
+        """
+
         if len(self.grid_list) == 1 and self.num_domains is not None:
             # Single grid repeated for multiple domains
             weight_combinations = itertools.product(
@@ -136,6 +153,12 @@ class MultiDomainGrid(Grid):
 
         Due to the combinatorial nature of the grid, the points are returned as a generator. Each
         point is a tuple of the points of the individual grids.
+
+        For a MultiDomainGrid formed from two grids, [(x11, y11), (x12, y12) ... (x1n, y1n)] and
+        [(x21, y21), (x22, y22) ... (x2m, y2m)], the combined points are calculated as follows:
+        For each combination of points (x1, y1) from the first grid and (x2, y2) from the second
+        2D grid, the combined point is a tuple of (x1i, y1i), (x2j, y2j) where (x1, y1) and (x2, y2)
+        are the points from the individual grids respectively.
         """
         if len(self.grid_list) == 1 and self.num_domains is not None:
             # Single grid repeated for multiple domains

--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -22,7 +22,7 @@
 import numpy as np
 from grid.basegrid import Grid
 import itertools
-from numbers import Number
+from itertools import islice
 
 
 class MultiDomainGrid(Grid):
@@ -221,8 +221,22 @@ class MultiDomainGrid(Grid):
 
         return integral_value
 
+    def get_localgrid(self, center, radius):
+        raise NotImplementedError(
+            "The get_local grid method is not implemented for multi-domain grids."
+        )
 
-from itertools import islice
+    def moments(
+        self,
+        orders: int,
+        centers: np.ndarray,
+        func_vals: np.ndarray,
+        type_mom: str = "cartesian",
+        return_orders: bool = False,
+    ):
+        raise NotImplementedError(
+            "The computation of moments is not implemented for multi-domain grids."
+        )
 
 
 def _chunked_iterator(iterator, size):

--- a/src/grid/tests/test_ngrid.py
+++ b/src/grid/tests/test_ngrid.py
@@ -66,6 +66,10 @@ class TestNgrid_linear(TestCase):
         with self.assertRaises(ValueError):
             MultiDomainGrid(grid_list=[self.linear_grid] * 3, num_domains=2)
 
+    def test_size(self):
+        """Assert that the size property works as expected."""
+        self.assertEqual(self.ngrid.size, 500**3)
+
     def test_init(self):
         """Assert that the init works as expected."""
         # case 1: the grid list is given and n is None

--- a/src/grid/tests/test_ngrid.py
+++ b/src/grid/tests/test_ngrid.py
@@ -24,7 +24,7 @@ from unittest import TestCase
 from grid.onedgrid import UniformInteger, GaussLegendre
 from grid.rtransform import BeckeRTransform, LinearInfiniteRTransform
 from grid.atomgrid import AtomGrid
-from grid.ngrid import Ngrid
+from grid.ngrid import MultiDomainGrid
 import pytest
 import itertools
 
@@ -46,37 +46,37 @@ class TestNgrid_linear(TestCase):
             self.linear_grid
         )
         # create a 3D grid with n equally spaced points between 0 and 1 along each axis
-        self.ngrid = Ngrid([self.linear_grid], 3)
+        self.ngrid = MultiDomainGrid([self.linear_grid], 3)
 
     def test_init_raises(self):
         """Assert that the init raises the correct error."""
         # case 1: the grid list is not given
         with self.assertRaises(ValueError):
-            Ngrid(grid_list=None)
+            MultiDomainGrid(grid_list=None)
         # case 2: the grid list is empty
         with self.assertRaises(ValueError):
-            Ngrid(grid_list=[])
+            MultiDomainGrid(grid_list=[])
         # case 3: the grid list is not a list of Grid
         with self.assertRaises(ValueError):
-            Ngrid(grid_list=[self.linear_grid, 1], n=None)
+            MultiDomainGrid(grid_list=[self.linear_grid, 1], num_domains=None)
         # case 4: n is negative
         with self.assertRaises(ValueError):
-            Ngrid(grid_list=[self.linear_grid], n=-1)
+            MultiDomainGrid(grid_list=[self.linear_grid], num_domains=-1)
         # case 5: n and the grid list have different lengths
         with self.assertRaises(ValueError):
-            Ngrid(grid_list=[self.linear_grid] * 3, n=2)
+            MultiDomainGrid(grid_list=[self.linear_grid] * 3, num_domains=2)
 
     def test_init(self):
         """Assert that the init works as expected."""
         # case 1: the grid list is given and n is None
-        ngrid = Ngrid(grid_list=[self.linear_grid, self.linear_grid, self.linear_grid])
+        ngrid = MultiDomainGrid(grid_list=[self.linear_grid, self.linear_grid, self.linear_grid])
         self.assertEqual(len(ngrid.grid_list), 3)
-        self.assertEqual(ngrid.n, None)
+        self.assertEqual(ngrid.num_domains, None)
 
         # case 2: the grid list is given (length 1) and n is not None
-        ngrid = Ngrid(grid_list=[self.linear_grid], n=3)
+        ngrid = MultiDomainGrid(grid_list=[self.linear_grid], num_domains=3)
         self.assertEqual(len(ngrid.grid_list), 1)
-        self.assertEqual(ngrid.n, 3)
+        self.assertEqual(ngrid.num_domains, 3)
 
     def test_single_grid_integration(self):
         """Assert that the integration works as expected for a single grid."""
@@ -86,7 +86,7 @@ class TestNgrid_linear(TestCase):
             return x**2
 
         # define a Ngrid with only one grid
-        ngrid = Ngrid(grid_list=[self.linear_grid])
+        ngrid = MultiDomainGrid(grid_list=[self.linear_grid])
         # integrate it
         result = ngrid.integrate(f)
         # check that the result is correct
@@ -100,7 +100,7 @@ class TestNgrid_linear(TestCase):
             return x**2 + y**2
 
         # define a Ngrid with two grids
-        ngrid = Ngrid(grid_list=[self.linear_grid], n=2)
+        ngrid = MultiDomainGrid(grid_list=[self.linear_grid], num_domains=2)
         # integrate it
         result = ngrid.integrate(f)
         # check that the result is correct
@@ -114,7 +114,7 @@ class TestNgrid_linear(TestCase):
             return x * y * z
 
         # define a Ngrid with three grids
-        ngrid = Ngrid(grid_list=[self.linear_grid], n=3)
+        ngrid = MultiDomainGrid(grid_list=[self.linear_grid], num_domains=3)
         # integrate it
         result = ngrid.integrate(f)
         # check that the result is correct
@@ -174,7 +174,7 @@ class TestNgrid_atom(TestCase):
         g = self.make_gaussian(self.center1, height, width)
 
         # define a Ngrid with only one atom grid
-        ngrid = Ngrid(grid_list=[self.atgrid1])
+        ngrid = MultiDomainGrid(grid_list=[self.atgrid1])
         # integrate it
         result = ngrid.integrate(g)
         ref_val = self.gaussian_integral(height, width)
@@ -195,7 +195,7 @@ class TestNgrid_atom(TestCase):
         func = lambda x, y: g1(x) * g2(y)
 
         # define a Ngrid with two grids
-        ngrid = Ngrid(grid_list=[self.atgrid1, self.atgrid2])
+        ngrid = MultiDomainGrid(grid_list=[self.atgrid1, self.atgrid2])
         # integrate it and compare with reference value
         result = ngrid.integrate(func)
         ref_val = self.gaussian_integral(height1, width1) * self.gaussian_integral(height2, width2)
@@ -220,7 +220,7 @@ class TestNgrid_atom(TestCase):
         func = lambda x, y, z: g1(x) * g2(y) * g3(z)
 
         # define a Ngrid with two grids
-        ngrid = Ngrid(grid_list=[self.atgrid1, self.atgrid2, self.atgrid3])
+        ngrid = MultiDomainGrid(grid_list=[self.atgrid1, self.atgrid2, self.atgrid3])
         # integrate it and compare with reference value
         result = ngrid.integrate(func)
         ref_val = (
@@ -323,7 +323,7 @@ class TestNgrid_mixed(TestCase):
         func = lambda x, y: g1(x) * g2(y)
 
         # define a Ngrid with only one atom grid
-        ngrid = Ngrid(grid_list=[self.onedgrid, self.atgrid1])
+        ngrid = MultiDomainGrid(grid_list=[self.onedgrid, self.atgrid1])
         # integrate it
         result = ngrid.integrate(func)
         ref_val = (

--- a/src/grid/tests/test_ngrid.py
+++ b/src/grid/tests/test_ngrid.py
@@ -182,6 +182,10 @@ class TestMultiDomainGrid_linear(TestCase):
         # check that the result is correct
         self.assertAlmostEqual(ref_value, result, places=6)
 
+
+class TestMultiDomainGrid_atom(TestCase):
+    """MultiDomainGrid tests class."""
+
     def setUp(self):
         """Set up atomgrid to use in the tests."""
         # construct a radial grid with 150 points
@@ -207,7 +211,8 @@ class TestMultiDomainGrid_linear(TestCase):
             The width of the gaussian."""
 
         def f(x):
-            r = np.linalg.norm(center - x, axis=1)
+            # axis=1 is needed to broadcast the norm correctly in the 3D case
+            r = np.linalg.norm(center - x, axis=-1)
             return height * np.exp(-(r**2) / (2 * width**2))
 
         return f
@@ -231,8 +236,9 @@ class TestMultiDomainGrid_linear(TestCase):
         # define a function to integrate
         g = self.make_gaussian(self.center1, height, width)
 
-        # define a Ngrid with only one atom grid
+        # # define a MultiDomainGrid with only one atom grid
         ngrid = MultiDomainGrid(grid_list=[self.atgrid1])
+        ngrid.integrate(g)
         # integrate it
         result = ngrid.integrate(g)
         ref_val = self.gaussian_integral(height, width)
@@ -250,9 +256,10 @@ class TestMultiDomainGrid_linear(TestCase):
         g2 = self.make_gaussian(self.center2, height2, width2)
 
         # function is product of two gaussians
-        func = lambda x, y: g1(x) * g2(y)
+        def func(x, y):
+            return g1(x) * g2(y)
 
-        # define a Ngrid with two grids
+        # define a MultiDomainGrid with two grids
         ngrid = MultiDomainGrid(grid_list=[self.atgrid1, self.atgrid2])
         # integrate it and compare with reference value
         result = ngrid.integrate(func)
@@ -277,7 +284,7 @@ class TestMultiDomainGrid_linear(TestCase):
         # function is product of two gaussians
         func = lambda x, y, z: g1(x) * g2(y) * g3(z)
 
-        # define a Ngrid with two grids
+        # define a MultiDomainGrid with two grids
         ngrid = MultiDomainGrid(grid_list=[self.atgrid1, self.atgrid2, self.atgrid3])
         # integrate it and compare with reference value
         result = ngrid.integrate(func)

--- a/src/grid/tests/test_ngrid.py
+++ b/src/grid/tests/test_ngrid.py
@@ -298,7 +298,7 @@ class TestMultiDomainGrid_atom(TestCase):
         self.assertAlmostEqual(result, ref_val, places=6)
 
 
-class TestNgrid_mixed(TestCase):
+class TestMultiDomainGrid_mixed_dimension_grids(TestCase):
     """Ngrid tests class."""
 
     def setUp(self):
@@ -387,7 +387,7 @@ class TestNgrid_mixed(TestCase):
         # function is product of two gaussians
         func = lambda x, y: g1(x) * g2(y)
 
-        # define a Ngrid with only one atom grid
+        # define a MultiDomainGrid with only one atom grid
         ngrid = MultiDomainGrid(grid_list=[self.onedgrid, self.atgrid1])
         # integrate it
         result = ngrid.integrate(func)


### PR DESCRIPTION
Refactored the ngrid module to improve readability and add features.

- Added weights property which returns the weights for each argument combination (due to its combinatorial nature returns a generator)
- Added points property which returns the combinations of arguments (due to its combinatorial nature returns a generator). Each point is a tuple with several arrays, each array corresponds to an argument of the multigrid function to integrate.
- Added support for non-vectorized functions. These will be evaluated point by point during the integration.

@PaulWAyers I think this PR improved the previous class. Nonetheless, I still have some doubts:
1. The current class used is a derived class of `Grid` because of this, several methods are inherited `moments`, `save` and `get_localgrid`. I think that `save` and `get_localgrid` can be implemented (I have some doubts about the meaning of `get_localgrid` in this context ), but I don't see how to get `moments`. 
2. This one is related to my previous doubt. Wouldn't be better to make a new class called perhaps `MultiDomainGridIntegrator` that is only responsible for integrating functions with more than one argument?