### PR TITLE
Fixed tox python version matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     pytest
     wheel
     setuptools
+    build
 commands =
     python -m build
     pip install .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, build, flake8, black
+envlist = py39, py310, py311, py312, py313, build, flake8, black
 skipsdist = true
 skip_missing_interpreters = true
 isolated_build = true
@@ -27,7 +27,7 @@ deps =
     wheel
     setuptools
 commands =
-    python setup.py -q sdist bdist_wheel
+    python -m build
     pip install .
     pytest --pyargs grid
 
@@ -42,7 +42,7 @@ deps =
     flake8-colors
 commands =
     flake8 --version
-    flake8 src/grid setup.py
+    flake8 src/grid
 
 [testenv:black]
 basepython = python3
@@ -71,5 +71,8 @@ omit = */test*
 
 [gh]
 python =
-    3.7 = py37, build, flake8, black
-    3.8 = py38
+    3.9 = py39, build, flake8, black
+    3.10 = py310
+    3.11 = py311
+    3.12 = py312
+    3.13 = py313


### PR DESCRIPTION
### Updates

- Changed tox test matrix to match requires-python in pyproject.toml.
- Removed references to unsupported Python versions (3.7, 3.8).
- Dropped setup.py from flake8 checks since it does not exist.
- Updated [gh].