### PR TITLE
Adds get_atomic_property method (issue #216)

### DIFF
--- a/src/grid/molgrid.py
+++ b/src/grid/molgrid.py
@@ -635,10 +635,11 @@ class MolGrid(Grid):
                 f"property_values must be of numpy array type, got {type(property_values)}"
             )
 
+        property_values = np.asarray(property_values).reshape(-1)
         if property_values.size != self.size:
             raise ValueError(
-                "property_values is not the same size as grid. \n"
-                f"property_values.size: {property_values.size}, self.size: {self.size}"
+                "property_values must be one-dimensional with the same length as the grid.\n"
+                f"property_values.shape: {property_values.shape}, expected: ({self.size},)"
             )
 
         # initialize output array
@@ -653,9 +654,7 @@ class MolGrid(Grid):
 
             # finding property of each atom
             atomic_property[i] = np.sum(
-                property_values[start_index:end_index]
-                * self.aim_weights[start_index:end_index]
-                * self.atweights[start_index:end_index]
+                property_values[start_index:end_index] * self.weights[start_index:end_index]
             )
 
         return atomic_property

--- a/src/grid/tests/test_molgrid.py
+++ b/src/grid/tests/test_molgrid.py
@@ -837,7 +837,7 @@ class TestMolGrid(TestCase):
         )
 
         wrong_size = np.ones(mg.size + 1)
-        with pytest.raises(ValueError, match="property_values is not the same size as grid"):
+        with pytest.raises(ValueError, match="property_values must be one-dimensional"):
             mg.get_atomic_property(wrong_size)
 
     def test_get_atomic_property_nonuniform(self):


### PR DESCRIPTION
This PR adds `get_atomic_property` method to the `MolGrid` class in `grid/src/grid/molgrid.py` that converts properties evaluated at grid points to properties per atom. This enables partitioning of molecular properties into contribution on each atom.

This PR also added 3 test cases to `src/grid/tests/test_molgrid.py` :

1.  `test_get_atomic_property_constant` : Verifies basic functionality with constant property values

- Verifies correct array size returned
- Verifies sum of atomic properties equals total integral

2. `test_get_atomic_property_wrong_size`: Error handling for invalid input

- Verifies `ValueError` is raised when input array size doesn't match grid size

3. `test_get_atomic_property_nonuniform`: Verifies basic functionality with with non uniform property.

- Verifies symmetric molecule should give equal atomic properties.

All tests pass locally!