### PR TITLE
Add lattice rules for (hyper)cubic grid integration

### DIFF
--- a/src/grid/__init__.py
+++ b/src/grid/__init__.py
@@ -29,6 +29,7 @@ from grid.becke import *
 from grid.cubic import *
 from grid.hirshfeld import *
 from grid.angular import *
+from grid.lattice import *
 from grid.molgrid import *
 from grid.ode import *
 from grid.onedgrid import *

--- a/src/grid/lattice.py
+++ b/src/grid/lattice.py
@@ -1,0 +1,307 @@
+# GRID is a numerical integration module for quantum chemistry.
+#
+# Copyright (C) 2011-2019 The GRID Development Team
+#
+# This file is part of GRID.
+#
+# GRID is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# GRID is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+r"""Lattice Rules for Integration on (Hyper)Cubic Grids."""
+
+import numpy as np
+from scipy.interpolate import LinearNDInterpolator
+
+from grid.basegrid import Grid
+
+
+# Tabulated generating vectors from UNSW (https://web.maths.unsw.edu.au/~fkuo/lattice/)
+# Truncated to first 100 dimensions for practical use
+# Format: dimension -> component value for N=2^20 (1048576)
+# Source: lattice-32001-1024-1048576.3600 (Order 2 weights, recommended)
+_GENERATING_VECTOR_ORDER2 = {
+    1: 1,
+    2: 182667,
+    3: 469891,
+    4: 498753,
+    5: 110745,
+    6: 446247,
+    7: 250185,
+    8: 118627,
+    9: 245333,
+    10: 283199,
+    11: 408519,
+    12: 391023,
+    13: 246327,
+    14: 126539,
+    15: 399185,
+    16: 461527,
+    17: 300343,
+    18: 69681,
+    19: 516695,
+    20: 436179,
+    21: 106383,
+    22: 238523,
+    23: 413283,
+    24: 70841,
+    25: 47719,
+    26: 300129,
+    27: 113029,
+    28: 123925,
+    29: 410745,
+    30: 211325,
+    31: 17489,
+    32: 511893,
+    33: 40767,
+    34: 186077,
+    35: 519471,
+    36: 255369,
+    37: 101819,
+    38: 243573,
+    39: 66189,
+    40: 152143,
+    41: 503455,
+    42: 113217,
+    43: 132603,
+    44: 463967,
+    45: 297717,
+    46: 157383,
+    47: 224015,
+    48: 502917,
+    49: 36237,
+    50: 94049,
+}
+
+
+class Lattice(Grid):
+    r"""Lattice rule for integration on a (hyper)cubic grid.
+
+    Lattice rules provide efficient equal-weight integration points for
+    multidimensional integration over the unit hypercube :math:`[0,1)^d`.
+    Points are generated using a generating vector :math:`\mathbf{z}`:
+
+    .. math::
+        \mathbf{x}_i = \left\{ \frac{i \mathbf{z}}{N} \right\} \quad \text{for } i = 0, \ldots, N-1
+
+    where :math:`\{x\}` denotes the fractional part of :math:`x`.
+
+    The integration weights are all equal to :math:`V/N`, where :math:`V` is the volume
+    of the integration domain.
+
+    References
+    ----------
+    - Sloan, I. H., & Joe, S. (1994). Lattice Methods for Multiple Integration.
+    - Kuo, F. Y., & Nuyens, D. (2016). Application of Quasi-Monte Carlo Methods to Elliptic PDEs
+      with Random Diffusion Coefficients: A Survey of Analysis and Implementation.
+    - UNSW Lattice Rules: https://web.maths.unsw.edu.au/~fkuo/lattice/
+
+    """
+
+    def __init__(
+        self,
+        n_points,
+        dimension,
+        generating_vector=None,
+        rule="order2",
+        origin=None,
+        axes=None,
+    ):
+        r"""Construct a Lattice grid.
+
+        Parameters
+        ----------
+        n_points : int
+            Number of integration points :math:`N`. Should be a power of 2 for embedded
+            lattice rules (e.g., 1024, 2048, 4096, ..., up to 1048576).
+        dimension : int
+            Dimension :math:`d` of the integration domain.
+        generating_vector : np.ndarray, shape (d,), optional
+            Custom generating vector :math:`\mathbf{z}`. If None, uses tabulated
+            vectors based on the `rule` parameter.
+        rule : str, optional
+            Which tabulated rule to use. Options are:
+            - "order2": Order-2 weights (recommended, default)
+            Currently only "order2" is implemented with a truncated table.
+        origin : np.ndarray, shape (d,), optional
+            Origin of the hypercube. Defaults to zero vector.
+        axes : np.ndarray, shape (d, d), optional
+            Axes defining the hypercube (as row vectors). Defaults to identity matrix
+            (unit hypercube). The lattice points are first generated on [0,1)^d and
+            then affine-transformed to the specified parallelepiped.
+
+        Raises
+        ------
+        ValueError
+            If n_points is not a power of 2, or if dimension exceeds available
+            tabulated vectors, or if rule is not recognized.
+
+        """
+        if not self._is_power_of_2(n_points):
+            raise ValueError(f"n_points must be a power of 2, got {n_points}")
+
+        if n_points > 1048576:
+            raise ValueError(
+                f"n_points must be <= 1048576 (2^20) for tabulated rules, got {n_points}"
+            )
+
+        if dimension < 1:
+            raise ValueError(f"dimension must be >= 1, got {dimension}")
+
+        if generating_vector is None:
+            if rule == "order2":
+                if dimension > len(_GENERATING_VECTOR_ORDER2):
+                    raise ValueError(
+                        f"Tabulated order2 rule only supports up to "
+                        f"{len(_GENERATING_VECTOR_ORDER2)} dimensions, got {dimension}"
+                    )
+                # Extract generating vector for the requested dimension
+                generating_vector = np.array(
+                    [_GENERATING_VECTOR_ORDER2[d] for d in range(1, dimension + 1)],
+                    dtype=np.int64,
+                )
+            else:
+                raise ValueError(f"Unknown rule: {rule}. Only 'order2' is supported.")
+        else:
+            generating_vector = np.asarray(generating_vector, dtype=np.int64)
+            if generating_vector.shape != (dimension,):
+                raise ValueError(
+                    f"generating_vector must have shape ({dimension},), "
+                    f"got {generating_vector.shape}"
+                )
+
+        # Set defaults for origin and axes
+        if origin is None:
+            origin = np.zeros(dimension)
+        else:
+            origin = np.asarray(origin, dtype=float)
+            if origin.shape != (dimension,):
+                raise ValueError(
+                    f"origin must have shape ({dimension},), got {origin.shape}"
+                )
+
+        if axes is None:
+            axes = np.eye(dimension)
+        else:
+            axes = np.asarray(axes, dtype=float)
+            if axes.shape != (dimension, dimension):
+                raise ValueError(
+                    f"axes must have shape ({dimension}, {dimension}), got {axes.shape}"
+                )
+            if np.abs(np.linalg.det(axes)) < 1e-10:
+                raise ValueError(
+                    f"axes must be linearly independent, got det(axes)={np.linalg.det(axes)}"
+                )
+
+        self._n_points = n_points
+        self._dimension = dimension
+        self._generating_vector = generating_vector
+        self._origin = origin
+        self._axes = axes
+        self._rule = rule
+
+        # Generate lattice points on [0,1)^d
+        points_unit = self._generate_lattice_points()
+
+        # Transform to the specified parallelepiped: x = origin + points_unit @ axes
+        points = origin + points_unit @ axes
+
+        # All weights are equal: V / N
+        volume = np.abs(np.linalg.det(axes))
+        weights = np.full(n_points, volume / n_points)
+
+        super().__init__(points, weights)
+
+    @staticmethod
+    def _is_power_of_2(n):
+        """Check if n is a power of 2."""
+        return n > 0 and (n & (n - 1)) == 0
+
+    def _generate_lattice_points(self):
+        r"""Generate lattice points on the unit hypercube [0,1)^d.
+
+        Returns
+        -------
+        np.ndarray, shape (N, d)
+            Lattice points in the unit hypercube.
+
+        """
+        # x_i = {i * z / N} for i = 0, ..., N-1
+        # where {x} is the fractional part
+        indices = np.arange(self._n_points, dtype=np.int64)
+        # Broadcasting: (N, 1) * (1, d) -> (N, d)
+        points_scaled = indices[:, None] * self._generating_vector[None, :]
+        # Apply modulo N and divide by N to get fractional parts in [0, 1)
+        points_unit = (points_scaled % self._n_points) / self._n_points
+        return points_unit
+
+    @property
+    def dimension(self):
+        """int: Dimension of the lattice grid."""
+        return self._dimension
+
+    @property
+    def generating_vector(self):
+        """np.ndarray: Generating vector used for the lattice rule."""
+        return self._generating_vector
+
+    @property
+    def origin(self):
+        """np.ndarray: Origin of the integration domain."""
+        return self._origin
+
+    @property
+    def axes(self):
+        """np.ndarray: Axes defining the integration domain."""
+        return self._axes
+
+    @property
+    def rule(self):
+        """str: Name of the lattice rule used."""
+        return self._rule
+
+    def interpolate(self, new_points, values):
+        r"""Interpolate function values at new points using linear interpolation.
+
+        Note: Lattice points are not structured as a tensor grid, so we use
+        scipy's LinearNDInterpolator which constructs a Delaunay triangulation.
+        This may be slow for high dimensions or large N.
+
+        Parameters
+        ----------
+        new_points : np.ndarray, shape (M, d)
+            Points at which to interpolate.
+        values : np.ndarray, shape (N,)
+            Function values at the lattice points.
+
+        Returns
+        -------
+        np.ndarray, shape (M,)
+            Interpolated values at new_points.
+
+        """
+        if values.shape[0] != self.size:
+            raise ValueError(
+                f"values must have length {self.size}, got {values.shape[0]}"
+            )
+        new_points = np.asarray(new_points)
+        if new_points.ndim == 1:
+            new_points = new_points.reshape(1, -1)
+        if new_points.shape[1] != self._dimension:
+            raise ValueError(
+                f"new_points must have {self._dimension} columns, "
+                f"got {new_points.shape[1]}"
+            )
+
+        # Use LinearNDInterpolator from scipy
+        interpolator = LinearNDInterpolator(self.points, values)
+        return interpolator(new_points)

--- a/src/grid/lattice.py
+++ b/src/grid/lattice.py
@@ -269,6 +269,28 @@ class Lattice(Grid):
         """str: Name of the lattice rule used."""
         return self._rule
 
+    def __getitem__(self, index):
+        """Return a subset of the grid as a base Grid object.
+
+        Slicing a Lattice returns a plain Grid because the subset
+        of a lattice rule is not itself a valid lattice rule.
+
+        Parameters
+        ----------
+        index : int or slice
+            Index or slice for selecting grid points.
+
+        Returns
+        -------
+        Grid
+            A Grid object containing the selected points and weights.
+
+        """
+        if isinstance(index, int):
+            return Grid(np.array([self.points[index]]), np.array([self.weights[index]]))
+        else:
+            return Grid(np.array(self.points[index]), np.array(self.weights[index]))
+
     def interpolate(self, new_points, values):
         r"""Interpolate function values at new points using linear interpolation.
 
@@ -292,6 +314,12 @@ class Lattice(Grid):
         if values.shape[0] != self.size:
             raise ValueError(
                 f"values must have length {self.size}, got {values.shape[0]}"
+            )
+        if self._dimension > 10:
+            raise ValueError(
+                f"Interpolation uses Delaunay triangulation which is infeasible "
+                f"for dimension > 10, got dimension={self._dimension}. "
+                f"Consider using an alternative interpolation method."
             )
         new_points = np.asarray(new_points)
         if new_points.ndim == 1:

--- a/src/grid/lattice.py
+++ b/src/grid/lattice.py
@@ -269,28 +269,6 @@ class Lattice(Grid):
         """str: Name of the lattice rule used."""
         return self._rule
 
-    def __getitem__(self, index):
-        """Return a subset of the grid as a base Grid object.
-
-        Slicing a Lattice returns a plain Grid because the subset
-        of a lattice rule is not itself a valid lattice rule.
-
-        Parameters
-        ----------
-        index : int or slice
-            Index or slice for selecting grid points.
-
-        Returns
-        -------
-        Grid
-            A Grid object containing the selected points and weights.
-
-        """
-        if isinstance(index, int):
-            return Grid(np.array([self.points[index]]), np.array([self.weights[index]]))
-        else:
-            return Grid(np.array(self.points[index]), np.array(self.weights[index]))
-
     def interpolate(self, new_points, values):
         r"""Interpolate function values at new points using linear interpolation.
 
@@ -314,12 +292,6 @@ class Lattice(Grid):
         if values.shape[0] != self.size:
             raise ValueError(
                 f"values must have length {self.size}, got {values.shape[0]}"
-            )
-        if self._dimension > 10:
-            raise ValueError(
-                f"Interpolation uses Delaunay triangulation which is infeasible "
-                f"for dimension > 10, got dimension={self._dimension}. "
-                f"Consider using an alternative interpolation method."
             )
         new_points = np.asarray(new_points)
         if new_points.ndim == 1:

--- a/src/grid/tests/test_lattice.py
+++ b/src/grid/tests/test_lattice.py
@@ -1,0 +1,302 @@
+# GRID is a numerical integration module for quantum chemistry.
+#
+# Copyright (C) 2011-2019 The GRID Development Team
+#
+# This file is part of GRID.
+#
+# GRID is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# GRID is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+r"""Tests for Lattice Rules."""
+
+from unittest import TestCase
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from grid.lattice import Lattice
+
+
+class TestLattice(TestCase):
+    r"""Test Lattice class."""
+
+    def test_raises_error_when_n_points_not_power_of_2(self):
+        r"""Test that n_points must be a power of 2."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=100, dimension=2)
+        self.assertIn("must be a power of 2", str(err.exception))
+
+    def test_raises_error_when_n_points_too_large(self):
+        r"""Test that n_points must be <= 2^20."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=2**21, dimension=2)
+        self.assertIn("must be <= 1048576", str(err.exception))
+
+    def test_raises_error_when_dimension_invalid(self):
+        r"""Test that dimension must be >= 1."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=0)
+        self.assertIn("must be >= 1", str(err.exception))
+
+    def test_raises_error_when_dimension_exceeds_table(self):
+        r"""Test that dimension must be within tabulated range."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=1000)
+        self.assertIn("only supports up to", str(err.exception))
+
+    def test_raises_error_for_unknown_rule(self):
+        r"""Test that rule must be recognized."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=2, rule="unknown")
+        self.assertIn("Unknown rule", str(err.exception))
+
+    def test_raises_error_for_invalid_generating_vector(self):
+        r"""Test that custom generating vector must have correct shape."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=3, generating_vector=np.array([1, 2]))
+        self.assertIn("must have shape (3,)", str(err.exception))
+
+    def test_raises_error_for_invalid_origin(self):
+        r"""Test that origin must have correct shape."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=3, origin=np.array([0, 0]))
+        self.assertIn("origin must have shape (3,)", str(err.exception))
+
+    def test_raises_error_for_invalid_axes(self):
+        r"""Test that axes must have correct shape."""
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=3, axes=np.eye(2))
+        self.assertIn("axes must have shape (3, 3)", str(err.exception))
+
+    def test_raises_error_for_singular_axes(self):
+        r"""Test that axes must be linearly independent."""
+        singular_axes = np.array([[1, 0, 0], [2, 0, 0], [0, 0, 1]])
+        with self.assertRaises(ValueError) as err:
+            Lattice(n_points=1024, dimension=3, axes=singular_axes)
+        self.assertIn("must be linearly independent", str(err.exception))
+
+    def test_lattice_properties(self):
+        r"""Test that lattice properties are correctly set."""
+        n_points = 1024
+        dimension = 3
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        assert_equal(lattice.size, n_points)
+        assert_equal(lattice.dimension, dimension)
+        assert_equal(lattice.rule, "order2")
+        assert_equal(lattice.points.shape, (n_points, dimension))
+        assert_equal(lattice.weights.shape, (n_points,))
+        assert_allclose(lattice.origin, np.zeros(dimension))
+        assert_allclose(lattice.axes, np.eye(dimension))
+
+    def test_weights_are_equal(self):
+        r"""Test that all weights are equal to V/N."""
+        n_points = 1024
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        # For unit cube, volume = 1
+        expected_weight = 1.0 / n_points
+        assert_allclose(lattice.weights, np.full(n_points, expected_weight))
+
+    def test_weights_with_custom_axes(self):
+        r"""Test that weights scale with volume."""
+        n_points = 1024
+        dimension = 2
+        # Create a 2x2 square
+        axes = np.array([[2.0, 0.0], [0.0, 2.0]])
+        lattice = Lattice(n_points=n_points, dimension=dimension, axes=axes)
+
+        # Volume = det(axes) = 4
+        expected_weight = 4.0 / n_points
+        assert_allclose(lattice.weights, np.full(n_points, expected_weight))
+
+    def test_points_in_unit_cube(self):
+        r"""Test that points are in [0, 1)^d for default parameters."""
+        n_points = 1024
+        dimension = 3
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        # All points should be in [0, 1)
+        assert np.all(lattice.points >= 0.0)
+        assert np.all(lattice.points < 1.0)
+
+    def test_points_with_custom_origin_and_axes(self):
+        r"""Test that points are correctly transformed."""
+        n_points = 1024
+        dimension = 2
+        origin = np.array([1.0, 2.0])
+        axes = np.array([[0.5, 0.0], [0.0, 0.5]])
+        lattice = Lattice(
+            n_points=n_points, dimension=dimension, origin=origin, axes=axes
+        )
+
+        # Points should be in [1, 1.5) x [2, 2.5)
+        assert np.all(lattice.points[:, 0] >= 1.0)
+        assert np.all(lattice.points[:, 0] < 1.5)
+        assert np.all(lattice.points[:, 1] >= 2.0)
+        assert np.all(lattice.points[:, 1] < 2.5)
+
+    def test_first_point_is_origin(self):
+        r"""Test that the first lattice point (i=0) is at the origin."""
+        n_points = 1024
+        dimension = 3
+        origin = np.array([1.0, 2.0, 3.0])
+        lattice = Lattice(n_points=n_points, dimension=dimension, origin=origin)
+
+        # For i=0, x_0 = {0 * z / N} = 0, so first point is origin
+        assert_allclose(lattice.points[0], origin)
+
+    def test_integration_of_constant_function(self):
+        r"""Test integration of f(x) = 1 gives volume."""
+        n_points = 2048
+        dimension = 3
+        axes = np.diag([2.0, 3.0, 4.0])  # Volume = 24
+        lattice = Lattice(n_points=n_points, dimension=dimension, axes=axes)
+
+        func_vals = np.ones(n_points)
+        integral = lattice.integrate(func_vals)
+
+        expected = 24.0
+        assert_allclose(integral, expected, rtol=1e-10)
+
+    def test_integration_of_linear_function(self):
+        r"""Test integration of f(x) = x_1 + x_2 on unit square."""
+        n_points = 4096
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        # f(x, y) = x + y
+        func_vals = lattice.points[:, 0] + lattice.points[:, 1]
+        integral = lattice.integrate(func_vals)
+
+        # Exact integral over [0,1]^2: int_0^1 int_0^1 (x+y) dx dy = 1
+        expected = 1.0
+        assert_allclose(integral, expected, rtol=1e-2)
+
+    def test_integration_of_quadratic_function(self):
+        r"""Test integration of f(x) = x^2 on unit interval."""
+        n_points = 8192
+        dimension = 1
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        # f(x) = x^2
+        func_vals = lattice.points[:, 0] ** 2
+        integral = lattice.integrate(func_vals)
+
+        # Exact integral over [0,1]: int_0^1 x^2 dx = 1/3
+        expected = 1.0 / 3.0
+        assert_allclose(integral, expected, rtol=1e-3)
+
+    def test_embedded_property(self):
+        r"""Test that lattice with N points is a subset of lattice with 2N points."""
+        n_points = 1024
+        dimension = 2
+        lattice_n = Lattice(n_points=n_points, dimension=dimension)
+        lattice_2n = Lattice(n_points=2 * n_points, dimension=dimension)
+
+        # Every other point in lattice_2n should match lattice_n
+        # Because x_i = {i*z/N} and x_{2i} = {2i*z/(2N)} = {i*z/N}
+        for i in range(n_points):
+            assert_allclose(lattice_n.points[i], lattice_2n.points[2 * i], rtol=1e-10)
+
+    def test_custom_generating_vector(self):
+        r"""Test using a custom generating vector."""
+        n_points = 1024
+        dimension = 3
+        custom_z = np.array([1, 123, 456])
+        lattice = Lattice(
+            n_points=n_points, dimension=dimension, generating_vector=custom_z
+        )
+
+        assert_allclose(lattice.generating_vector, custom_z)
+
+        # Verify first few points manually
+        # x_0 = {0 * z / 1024} = [0, 0, 0]
+        assert_allclose(lattice.points[0], [0.0, 0.0, 0.0])
+
+        # x_1 = {1 * [1, 123, 456] / 1024} = [1/1024, 123/1024, 456/1024]
+        expected_1 = np.array([1.0, 123.0, 456.0]) / 1024.0
+        assert_allclose(lattice.points[1], expected_1)
+
+    def test_interpolation_linear_function(self):
+        r"""Test interpolation of a linear function."""
+        n_points = 2048
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        # f(x, y) = 2*x + 3*y
+        func_vals = 2 * lattice.points[:, 0] + 3 * lattice.points[:, 1]
+
+        # Interpolate at some test points
+        test_points = np.array([[0.25, 0.25], [0.5, 0.5], [0.75, 0.75]])
+        interpolated = lattice.interpolate(test_points, func_vals)
+
+        # For linear function, interpolation should be exact
+        expected = 2 * test_points[:, 0] + 3 * test_points[:, 1]
+        assert_allclose(interpolated, expected, rtol=1e-5)
+
+    def test_interpolation_raises_error_for_wrong_values_length(self):
+        r"""Test that interpolation raises error for wrong values length."""
+        n_points = 1024
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        with self.assertRaises(ValueError) as err:
+            lattice.interpolate(np.array([[0.5, 0.5]]), np.array([1.0, 2.0]))
+        self.assertIn("values must have length", str(err.exception))
+
+    def test_interpolation_raises_error_for_wrong_dimension(self):
+        r"""Test that interpolation raises error for wrong dimension."""
+        n_points = 1024
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        func_vals = np.ones(n_points)
+        with self.assertRaises(ValueError) as err:
+            lattice.interpolate(np.array([[0.5, 0.5, 0.5]]), func_vals)
+        self.assertIn("must have 2 columns", str(err.exception))
+
+    def test_different_dimensions(self):
+        r"""Test lattice in different dimensions."""
+        for dimension in [1, 2, 3, 5, 10]:
+            n_points = 1024
+            lattice = Lattice(n_points=n_points, dimension=dimension)
+
+            assert_equal(lattice.dimension, dimension)
+            assert_equal(lattice.points.shape, (n_points, dimension))
+            assert_equal(len(lattice.generating_vector), dimension)
+
+    def test_save_and_load(self):
+        r"""Test saving lattice to file."""
+        import os
+        import tempfile
+
+        n_points = 1024
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        # Create temp file and close it immediately
+        fd, filename = tempfile.mkstemp(suffix=".npz")
+        os.close(fd)  # Close the file descriptor
+
+        try:
+            lattice.save(filename)
+            loaded = np.load(filename)
+
+            assert_allclose(loaded["points"], lattice.points)
+            assert_allclose(loaded["weights"], lattice.weights)
+            loaded.close()  # Close the npz file before deletion
+        finally:
+            if os.path.exists(filename):
+                os.unlink(filename)

--- a/src/grid/tests/test_lattice.py
+++ b/src/grid/tests/test_lattice.py
@@ -182,7 +182,7 @@ class TestLattice(TestCase):
 
         # Exact integral over [0,1]^2: int_0^1 int_0^1 (x+y) dx dy = 1
         expected = 1.0
-        assert_allclose(integral, expected, rtol=1e-2)
+        assert_allclose(integral, expected, rtol=1e-3)
 
     def test_integration_of_quadratic_function(self):
         r"""Test integration of f(x) = x^2 on unit interval."""
@@ -300,3 +300,69 @@ class TestLattice(TestCase):
         finally:
             if os.path.exists(filename):
                 os.unlink(filename)
+
+    def test_getitem_single_index(self):
+        r"""Test that indexing a Lattice returns a valid Grid."""
+        from grid.basegrid import Grid
+
+        n_points = 1024
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        sub = lattice[0]
+        assert isinstance(sub, Grid)
+        assert_equal(sub.size, 1)
+        assert_allclose(sub.points[0], lattice.points[0])
+        assert_allclose(sub.weights[0], lattice.weights[0])
+
+    def test_getitem_slice(self):
+        r"""Test that slicing a Lattice returns a valid Grid."""
+        from grid.basegrid import Grid
+
+        n_points = 1024
+        dimension = 2
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        sub = lattice[10:20]
+        assert isinstance(sub, Grid)
+        assert_equal(sub.size, 10)
+        assert_allclose(sub.points, lattice.points[10:20])
+        assert_allclose(sub.weights, lattice.weights[10:20])
+
+    def test_integration_of_smooth_function(self):
+        r"""Test integration of sin(pi*x)*sin(pi*y)*sin(pi*z) on [0,1]^3."""
+        n_points = 4096
+        dimension = 3
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+
+        func_vals = np.prod(np.sin(np.pi * lattice.points), axis=1)
+        integral = lattice.integrate(func_vals)
+
+        expected = (2.0 / np.pi) ** 3
+        assert_allclose(integral, expected, rtol=1e-3)
+
+    def test_error_convergence(self):
+        r"""Test that integration error decreases as N doubles."""
+        dimension = 2
+        exact = (2.0 / np.pi) ** 2
+        errors = []
+        for k in range(8, 15):
+            n = 2**k
+            lat = Lattice(n_points=n, dimension=dimension)
+            fvals = np.prod(np.sin(np.pi * lat.points), axis=1)
+            error = abs(lat.integrate(fvals) - exact)
+            errors.append(error)
+        # Each doubling should reduce error
+        for i in range(len(errors) - 1):
+            assert errors[i + 1] < errors[i]
+
+    def test_interpolation_raises_error_for_high_dimension(self):
+        r"""Test that interpolation raises error for dimension > 10."""
+        n_points = 1024
+        dimension = 11
+        lattice = Lattice(n_points=n_points, dimension=dimension)
+        func_vals = np.ones(n_points)
+
+        with self.assertRaises(ValueError) as err:
+            lattice.interpolate(np.zeros((1, dimension)), func_vals)
+        self.assertIn("infeasible", str(err.exception))

--- a/src/grid/tests/test_lattice.py
+++ b/src/grid/tests/test_lattice.py
@@ -182,7 +182,7 @@ class TestLattice(TestCase):
 
         # Exact integral over [0,1]^2: int_0^1 int_0^1 (x+y) dx dy = 1
         expected = 1.0
-        assert_allclose(integral, expected, rtol=1e-3)
+        assert_allclose(integral, expected, rtol=1e-2)
 
     def test_integration_of_quadratic_function(self):
         r"""Test integration of f(x) = x^2 on unit interval."""
@@ -300,69 +300,3 @@ class TestLattice(TestCase):
         finally:
             if os.path.exists(filename):
                 os.unlink(filename)
-
-    def test_getitem_single_index(self):
-        r"""Test that indexing a Lattice returns a valid Grid."""
-        from grid.basegrid import Grid
-
-        n_points = 1024
-        dimension = 2
-        lattice = Lattice(n_points=n_points, dimension=dimension)
-
-        sub = lattice[0]
-        assert isinstance(sub, Grid)
-        assert_equal(sub.size, 1)
-        assert_allclose(sub.points[0], lattice.points[0])
-        assert_allclose(sub.weights[0], lattice.weights[0])
-
-    def test_getitem_slice(self):
-        r"""Test that slicing a Lattice returns a valid Grid."""
-        from grid.basegrid import Grid
-
-        n_points = 1024
-        dimension = 2
-        lattice = Lattice(n_points=n_points, dimension=dimension)
-
-        sub = lattice[10:20]
-        assert isinstance(sub, Grid)
-        assert_equal(sub.size, 10)
-        assert_allclose(sub.points, lattice.points[10:20])
-        assert_allclose(sub.weights, lattice.weights[10:20])
-
-    def test_integration_of_smooth_function(self):
-        r"""Test integration of sin(pi*x)*sin(pi*y)*sin(pi*z) on [0,1]^3."""
-        n_points = 4096
-        dimension = 3
-        lattice = Lattice(n_points=n_points, dimension=dimension)
-
-        func_vals = np.prod(np.sin(np.pi * lattice.points), axis=1)
-        integral = lattice.integrate(func_vals)
-
-        expected = (2.0 / np.pi) ** 3
-        assert_allclose(integral, expected, rtol=1e-3)
-
-    def test_error_convergence(self):
-        r"""Test that integration error decreases as N doubles."""
-        dimension = 2
-        exact = (2.0 / np.pi) ** 2
-        errors = []
-        for k in range(8, 15):
-            n = 2**k
-            lat = Lattice(n_points=n, dimension=dimension)
-            fvals = np.prod(np.sin(np.pi * lat.points), axis=1)
-            error = abs(lat.integrate(fvals) - exact)
-            errors.append(error)
-        # Each doubling should reduce error
-        for i in range(len(errors) - 1):
-            assert errors[i + 1] < errors[i]
-
-    def test_interpolation_raises_error_for_high_dimension(self):
-        r"""Test that interpolation raises error for dimension > 10."""
-        n_points = 1024
-        dimension = 11
-        lattice = Lattice(n_points=n_points, dimension=dimension)
-        func_vals = np.ones(n_points)
-
-        with self.assertRaises(ValueError) as err:
-            lattice.interpolate(np.zeros((1, dimension)), func_vals)
-        self.assertIn("infeasible", str(err.exception))


### PR DESCRIPTION
This PR implements lattice rules for efficient numerical integration over (hyper)cubic grids, addressing issue #241 .

Following the references provided in the issue ([Sloan's paper](https://www.maths.unsw.edu.au/sites/default/files/amr06_35_0.pdf) and the [UNSW lattice rules database](https://web.maths.unsw.edu.au/~fkuo/lattice/)), I've implemented rank-1 lattice rules as a new integration method.
**Implementation :**

- New Lattice class using tabulated generating vectors from [UNSW database](https://web.maths.unsw.edu.au/~fkuo/lattice/)
- Supports embedded lattice rules (powers of 2, up to 2²⁰ points)
- Equal-weight integration with formula: $\mathbf{x}_k = { \frac{k \cdot \mathbf{z}}{n} }$
- Works with arbitrary parallelepipeds via affine transformation
- Supports up to 50 dimensions (extensible to 3600+ if needed)
- Includes basic interpolation via `scipy.interpolate.LinearNDInterpolator`

**Testing:**

- Input validation, point generation, integration accuracy
- Embedded property verification, interpolation, file I/O
<img width="878" height="476" alt="Screenshot 2026-02-11 023415" src="https://github.com/user-attachments/assets/c5650028-eb34-41e4-86a0-2afd9a2b2cb4" />
closes #241 