### PR TITLE
Refactor `generate_real_spherical_harmonics_scipy` to use scipy's `sph_harm_y_all`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy>=1.16
-pytest>=2.6
-scipy>=1.4
+pytestnumpy>=1.23.5
+pytest>=8.0.0
+scipy>=1.15.0
 matplotlib
 importlib_resources
 sympy

--- a/src/grid/tests/test_utils.py
+++ b/src/grid/tests/test_utils.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
 """Utils function test file."""
+
 from unittest import TestCase
 
 import numpy as np
@@ -274,6 +275,24 @@ def test_spherical_harmonic_recursion_against_scipy(numb_pts, max_degree):
     pytho_sol = generate_real_spherical_harmonics(max_degree, theta, phi)
     scipy_sol = generate_real_spherical_harmonics_scipy(max_degree, theta, phi)
     assert_allclose(pytho_sol, scipy_sol, atol=1e-10)
+
+
+def test_generate_real_spherical_harmonics_scipy_raises_for_non_1d_angles():
+    """Test scipy spherical harmonics helper rejects non-1D angle arrays."""
+    theta = np.random.uniform(0.0, 2.0 * np.pi, size=(8, 1))
+    phi = np.random.uniform(0.0, np.pi, size=(8, 1))
+
+    with pytest.raises(ValueError, match="1D"):
+        generate_real_spherical_harmonics_scipy(3, theta, phi)
+
+
+def test_generate_real_spherical_harmonics_scipy_raises_for_mismatched_angle_shapes():
+    """Test scipy spherical harmonics helper rejects mismatched angle array shapes."""
+    theta = np.random.uniform(0.0, 2.0 * np.pi, size=(8,))
+    phi = np.random.uniform(0.0, np.pi, size=(10,))
+
+    with pytest.raises(ValueError, match="same shape"):
+        generate_real_spherical_harmonics_scipy(3, theta, phi)
 
 
 @pytest.mark.parametrize("numb_pts, max_degree", [[1000, 4], [5000, 2], [100, 15], [10, 100]])

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -558,7 +558,7 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     in associated Legendre functions. We tested up to :math:`l_{max} = 600` without NaNs.
     """
     if l_max < 0:
-        raise ValueError(f"lmax should be non-negative, got l_amx={l_max}")
+        raise ValueError(f"lmax should be non-negative, got l_max={l_max}")
 
     theta = np.asarray(theta)
     phi = np.asarray(phi)

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -578,23 +578,18 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     phase_cor = np.where(m_list == 0, 1.0, np.sqrt(2) * (-1) ** np.abs(m_list))
     no_phase = np.einsum("j, ijk -> ijk", phase_cor, sph_vals)
 
-    total_sph = np.zeros((0, len(theta)), dtype=float)
+    n_pts = len(theta)
+    total_sph = np.empty(((l_max + 1) ** 2, n_pts), dtype=float)
     for l_val in range(l_max + 1):
         # spherical harmonics for degree l_val and all orders m = 0, 1, ..., l_val, -l_val, ..., -1
         sph_degree_pos = no_phase[l_val, : l_val + 1]  # m = 0..l_val
-
-        zero_real_sph = sph_degree_pos[0].real
-        pos_real_sph = sph_degree_pos[1:].real
+        # degrees before l_val sum_k=0^(l_val-1) (2k+1) = l_val^2
+        row_start = l_val**2
+        row_end = (l_val + 1) ** 2
+        total_sph[row_start] = sph_degree_pos[0].real  # m = 0 real part
+        total_sph[row_start + 1 : row_end : 2] = sph_degree_pos[1:].real  # m > 0 real part
         # negative m real is the imaginary part of the positive m spherical harmonic
-        neg_real_sph = sph_degree_pos[1:].imag
-
-        # Build HORTON order for this l: 0, +1, -1, +2, -2, ...
-        degree_block = np.empty((2 * l_val + 1, len(theta)), dtype=float)
-        degree_block[0] = zero_real_sph
-        degree_block[1::2] = pos_real_sph  # positive m real part in the odd rows
-        degree_block[2::2] = neg_real_sph  # negative m real part in the even rows
-
-        total_sph = np.vstack((total_sph, degree_block))
+        total_sph[row_start + 2 : row_end : 2] = sph_degree_pos[1:].imag
 
     return total_sph
 

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -554,8 +554,9 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
 
     Notes
     -----
-    - Spherical harmonics in SciPy may return NaNs for large degrees due to numerical instability
-    in associated Legendre functions. We tested up to :math:`l_{max} = 600` without NaNs.
+    - Spherical harmonics in SciPy may return NaNs for large degrees due to numerical
+      instability in associated Legendre functions. We tested up to
+      :math:`l_{max} = 600` without NaNs.
     """
     if l_max < 0:
         raise ValueError(f"lmax should be non-negative, got l_max={l_max}")

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -567,6 +567,11 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     if theta.shape != phi.shape:
         raise ValueError("theta and phi must have the same shape")
 
+    if theta.ndim != 1 or phi.ndim != 1:
+        raise ValueError(
+            f"theta and phi must be 1D arrays, got theta.ndim={theta.ndim}, phi.ndim={phi.ndim}"
+        )
+
     # sph_vals (i, j) corresponds to degree i and order j for all 0 <= i <= n and -m <= j <= m
     sph_vals = sph_harm_y_all(l_max, l_max, phi, theta)
 

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -554,9 +554,8 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
 
     Notes
     -----
-    - SciPy spherical harmonics is known (Jan 30, 2024) to give NaN when the degree is large,
-      for our experience, when l >= 86.
-
+    - Spherical harmonics in SciPy may return NaNs for large degrees due to numerical instability
+    in associated Legendre functions. We tested up to :math:`l_{max} = 600` without NaNs.
     """
     if l_max < 0:
         raise ValueError(f"lmax should be non-negative, got l_amx={l_max}")

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -20,7 +20,7 @@
 """Utility Module."""
 
 import numpy as np
-from scipy.special import sph_harm_y
+from scipy.special import sph_harm_y, sph_harm_y_all
 from scipy.constants import physical_constants, angstrom
 
 _BOHR_RADIUS_M = physical_constants["Bohr radius"][0]
@@ -561,33 +561,41 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     if l_max < 0:
         raise ValueError(f"lmax should be non-negative, got l_amx={l_max}")
 
+    theta = np.asarray(theta)
+    phi = np.asarray(phi)
+
+    if theta.shape != phi.shape:
+        raise ValueError("theta and phi must have the same shape")
+
+    # sph_vals (i, j) corresponds to degree i and order j for all 0 <= i <= n and -m <= j <= m
+    sph_vals = sph_harm_y_all(l_max, l_max, phi, theta)
+
+    # Orders m arranged to match sph_vals column layout:
+    # first non-negative m (0, 1, ..., l_max), then negative m (-l_max, ..., -1)
+    m_list = np.concatenate([np.arange(0, l_max + 1), np.arange(-l_max, 0)])
+
+    # Remove Conway phase from SciPy and apply sqrt(2) factor for m != 0
+    phase_cor = np.where(m_list == 0, 1.0, np.sqrt(2) * (-1) ** np.abs(m_list))
+    no_phase = np.einsum("j, ijk -> ijk", phase_cor, sph_vals)
+
     total_sph = np.zeros((0, len(theta)), dtype=float)
-    l_list = np.arange(l_max + 1)
-    for l_val in l_list:
-        # generate m=0 real spherical harmonic
-        zero_real_sph = sph_harm_y(l_val, 0, phi, theta).real
+    for l_val in range(l_max + 1):
+        # spherical harmonics for degree l_val and all orders m = 0, 1, ..., l_val, -l_val, ..., -1
+        sph_degree_pos = no_phase[l_val, : l_val + 1]  # m = 0..l_val
 
-        # generate order m=positive real spherical harmonic: sqrt(2) * (-1)^m * Re(Y_l^m)
-        m_list_p = np.arange(1, l_val + 1, dtype=int)
-        pos_real_sph = (
-            np.sqrt(2)
-            * (-1) ** m_list_p[:, None]
-            * sph_harm_y(l_val, m_list_p[:, None], phi, theta).real
-            # Remove Conway phase from SciPy
-        )
-        # generate order m=negative real spherical harmonic: sqrt(2) * (-1)^m * Im(Y_l^m)
-        neg_real_sph = (
-            np.sqrt(2)
-            * (-1) ** m_list_p[:, None]
-            * sph_harm_y(
-                l_val, m_list_p[:, None], phi, theta
-            ).imag  # Remove Conway phase from SciPy
-        )
+        zero_real_sph = sph_degree_pos[0].real
+        pos_real_sph = sph_degree_pos[1:].real
+        # negative m real is the imaginary part of the positive m spherical harmonic
+        neg_real_sph = sph_degree_pos[1:].imag
 
-        # Convert to horton 2 order
-        horton_ord = [[pos_real_sph[i], neg_real_sph[i]] for i in range(0, l_val)]
-        horton_ord = tuple(x for sublist in horton_ord for x in sublist)
-        total_sph = np.vstack((total_sph, zero_real_sph, *horton_ord))
+        # Build HORTON order for this l: 0, +1, -1, +2, -2, ...
+        degree_block = np.empty((2 * l_val + 1, len(theta)), dtype=float)
+        degree_block[0] = zero_real_sph
+        degree_block[1::2] = pos_real_sph  # positive m real part in the odd rows
+        degree_block[2::2] = neg_real_sph  # negative m real part in the even rows
+
+        total_sph = np.vstack((total_sph, degree_block))
+
     return total_sph
 
 

--- a/src/grid/utils.py
+++ b/src/grid/utils.py
@@ -570,19 +570,17 @@ def generate_real_spherical_harmonics_scipy(l_max: int, theta: np.ndarray, phi: 
     # sph_vals (i, j) corresponds to degree i and order j for all 0 <= i <= n and -m <= j <= m
     sph_vals = sph_harm_y_all(l_max, l_max, phi, theta)
 
-    # Orders m arranged to match sph_vals column layout:
-    # first non-negative m (0, 1, ..., l_max), then negative m (-l_max, ..., -1)
-    m_list = np.concatenate([np.arange(0, l_max + 1), np.arange(-l_max, 0)])
-
-    # Remove Conway phase from SciPy and apply sqrt(2) factor for m != 0
-    phase_cor = np.where(m_list == 0, 1.0, np.sqrt(2) * (-1) ** np.abs(m_list))
-    no_phase = np.einsum("j, ijk -> ijk", phase_cor, sph_vals)
+    # Remove Conway phase from SciPy and apply sqrt(2) factor for m != 0.
+    # Only non-negative orders m = 0..l_max are used below.
+    phase_cor_pos = np.ones(l_max + 1, dtype=float)
+    if l_max > 0:
+        phase_cor_pos[1:] = np.sqrt(2) * (-1.0) ** np.arange(1, l_max + 1)
 
     n_pts = len(theta)
     total_sph = np.empty(((l_max + 1) ** 2, n_pts), dtype=float)
     for l_val in range(l_max + 1):
-        # spherical harmonics for degree l_val and all orders m = 0, 1, ..., l_val, -l_val, ..., -1
-        sph_degree_pos = no_phase[l_val, : l_val + 1]  # m = 0..l_val
+        # spherical harmonics for degree l_val and non-negative orders m = 0..l_val
+        sph_degree_pos = sph_vals[l_val, : l_val + 1] * phase_cor_pos[: l_val + 1, None]
         # degrees before l_val sum_k=0^(l_val-1) (2k+1) = l_val^2
         row_start = l_val**2
         row_end = (l_val + 1) ** 2


### PR DESCRIPTION
The new version of the function is more stable for high `l` values.