### PR TITLE
Fix Trefethen(Strip)General

### DIFF
--- a/src/grid/onedgrid.py
+++ b/src/grid/onedgrid.py
@@ -897,7 +897,7 @@ class TrefethenGeneral(OneDGrid):
 
     name = "Trefethen-Polynomial"
 
-    def __init__(self, npoints: int, quadrature: OneDGrid, d=9):
+    def __init__(self, npoints: int, quadrature: OneDGrid, d=9, **quadrature_params):
         r"""Generate 1D grid on :math:`[-1,1]` interval based on Trefethen-General.
 
         Parameters
@@ -909,6 +909,8 @@ class TrefethenGeneral(OneDGrid):
         d :
             Odd degree of the Taylor series polynomial of :math:`\sin^{-1}`\.
             Only d=1,5,9 are supported.
+        quadrature_params : dict
+            Additional parameters to pass to the General one-dimensional grid.
 
         Returns
         -------
@@ -918,7 +920,7 @@ class TrefethenGeneral(OneDGrid):
         if not issubclass(quadrature, OneDGrid):
             raise TypeError(f"Quadrature {type(OneDGrid)} should be of type OneDgrid.")
 
-        grid = quadrature(npoints)
+        grid = quadrature(npoints, **quadrature_params)
 
         if d == 1:
             points = grid.points
@@ -1057,7 +1059,7 @@ class TrefethenStripGeneral(OneDGrid):
 
     name = "Trefethen-Strip-General"
 
-    def __init__(self, npoints: int, quadrature, rho: float = 1.1):
+    def __init__(self, npoints: int, quadrature, rho: float = 1.1, **quadrature_params):
         r"""Generate grid on :math:`[-1,1]` interval based on Trefethen-General.
 
         Parameters
@@ -1071,7 +1073,7 @@ class TrefethenStripGeneral(OneDGrid):
             One-dimensional grid instance.
 
         """
-        grid = quadrature(npoints)
+        grid = quadrature(npoints, **quadrature_params)
         points = _gstrip(rho, grid.points)
         weights = _dergstrip(rho, grid.points) * grid.weights
 

--- a/src/grid/tests/test_onedgrid.py
+++ b/src/grid/tests/test_onedgrid.py
@@ -579,6 +579,14 @@ class TestOneDGrid(TestCase):
         assert_allclose(grid.points, new.points)
         assert_allclose(grid.weights, new.weights)
 
+    def test_TrefethenGeneral_quadrature_params(self):
+        """Test for Trefethen - new quadrature params variable."""
+        grid = TrefethenGeneral(11, TanhSinh, 1)
+        new =  TrefethenGeneral(11, TanhSinh, 1, **{"delta":0.1})
+
+        assert_allclose(grid.points, new.points)
+        assert_allclose(grid.weights, new.weights)
+        
     def test_AuxiliarTrefethenStrip(self):
         """Test for Auxiliary functions using in Trefethen Strip."""
         xref = np.array([-1.0, 0.0, 1.0])


### PR DESCRIPTION
TrefethenGeneral and TrefethenStripGeneral OneDGrids can take any OneD Quadrature and transform it. Some OneDGrids have extra parameters which the Trefethen transforms don't account for (e.g. TanhSinh has an additional parameter delta: float = 0.1). The added code corrects this and have tested it.