### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -176,7 +176,7 @@ class MultiDomainGrid(Grid):
 
         Parameters
         ----------
-        integrand : callable
+        integrand_function : callable
             Integrand function to integrate. It must take a list of arguments (one for each domain)
             with the same dimension as the grid points used for the corresponding domain and return
             a float (e.g. a function of the form f([x1,y1,z1], [x2,y2,z2]) -> float).

--- a/src/grid/ngrid.py
+++ b/src/grid/ngrid.py
@@ -180,9 +180,6 @@ class MultiDomainGrid(Grid):
             Integrand function to integrate. It must take a list of arguments (one for each domain)
             with the same dimension as the grid points used for the corresponding domain and return
             a float (e.g. a function of the form f([x1,y1,z1], [x2,y2,z2]) -> float).
-        integration_chunk_size : int, optional
-            Number of points to integrate at once. This parameter can be used to control the
-            memory usage of the integration. Default is 1000.
         non_vectorized : bool, optional
             Set to True if the integrand is not vectorized. Default is False. If True, the integrand
             will be called for each point of the grid separately without vectorization. This implies

--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -512,7 +512,7 @@ def _evaluate_coeffs_on_points(x: np.ndarray, coeff: list | np.ndarray):
     ----------
     x : ndarray(N,)
         Points of the independent variable/domain.
-    coeffs : list[callable or float] or ndarray(K + 1,)
+    coeff : list[callable or float] or ndarray(K + 1,)
         Coefficients :math:`a_k` of each term :math:`\frac{d^k y(x)}{d x^k}`
         ordered from 0 to K.  Each coefficient can either be a callable function
         :math:`a_k(x)` or a constant number :math:`a_k`.

--- a/src/grid/rtransform.py
+++ b/src/grid/rtransform.py
@@ -1957,7 +1957,7 @@ class HandyRTransform(BaseTransform):
 
         Parameters
         ----------
-        array: np.ndarray(N,)
+        x: np.ndarray(N,)
             One dimensional array in :math:`[-1,1]`\.
 
         Returns


### PR DESCRIPTION
### Description

Three docstrings documented parameter names that do not match their function signatures:

- `NumericalIntegrand.integrate` (`src/grid/ngrid.py`) documented `integrand`, but the parameter is `integrand_function`.
- `_evaluate_coeffs_on_points` (`src/grid/ode.py`) documented `coeffs`, but the parameter is `coeff`.
- `deriv3` (`src/grid/rtransform.py`) documented `array`, but the parameter is `x`.

This corrects the documented names to match each signature. Documentation-only change.
