### PR TITLE
Use a deterministic initial guess in solve_ode_bvp

### DIFF
--- a/src/grid/ode.py
+++ b/src/grid/ode.py
@@ -210,7 +210,9 @@ def solve_ode_bvp(
         See `scipy.integrate.solve_bvp` function for more info.
     initial_guess_y : ndarray(K, N), optional
         Initial guess for :math:`y(x), \cdots, \frac{d^{K} y}{d x^{K}}` at the points `x`.
-        If not provided, then random set of points from 0 to 1.
+        If not provided, an all-zeros guess is used. Since this routine only solves
+        linear ODEs, the initial guess does not change the converged solution; it only
+        affects mesh refinement. A deterministic default makes the solver reproducible.
     no_derivatives : bool, optional
         If true, when transform is used then it only returns the solution :math:`y(x)` rather
         than its derivative. If false, it includes the derivatives up to :math:`P-1`.
@@ -256,9 +258,12 @@ def solve_ode_bvp(
             conds.append(bonds[i][deriv] - value)
         return np.array(conds)
 
-    # Generate random initial guess if not provided.
+    # Use a deterministic (all-zeros) initial guess if not provided. The ODE solved
+    # here is linear, so the guess cannot affect the converged solution, only the mesh
+    # adaptation; a fixed default keeps repeated solves (e.g. the Poisson solvers)
+    # reproducible instead of randomly converging or hitting ``max_nodes``.
     if initial_guess_y is None:
-        initial_guess_y = np.random.rand(order, x.size)
+        initial_guess_y = np.zeros((order, x.size))
 
     # Solve the ODE
     if transform:

--- a/src/grid/tests/test_ode.py
+++ b/src/grid/tests/test_ode.py
@@ -344,6 +344,34 @@ def test_solve_ode_bvp_against_analytic_example(fx, coeffs, bvp, solutions):
     assert_allclose(res(rand_pts), solutions(rand_pts), atol=1e-5)
 
 
+def test_solve_ode_bvp_default_initial_guess_is_deterministic():
+    r"""The default (unspecified) initial guess must not depend on global RNG state.
+
+    ``solve_ode_bvp`` previously seeded ``initial_guess_y`` with ``np.random.rand``,
+    which made repeated solves (and every Poisson solve, which never passes a guess)
+    non-reproducible. Solving the same linear BVP twice under different global RNG
+    states should now give bit-identical results.
+    """
+    # y'' = 1 with y(0) = 0, y'(0) = -1  ->  y(x) = x**2 / 2 - x
+    x = np.arange(0.0, 2.0, 0.1)
+
+    def fx(x):
+        return np.ones(x.size)
+
+    coeffs = [0, 0, 1]
+    bd_cond = [[0, 0, 0.0], [0, 1, -1.0]]
+    probe = np.arange(0.0, 2.0, 0.25)
+
+    np.random.seed(0)
+    first = solve_ode_bvp(x, fx, coeffs, bd_cond)(probe)[0]
+    np.random.seed(12345)
+    _ = np.random.rand(50)  # perturb global RNG state
+    second = solve_ode_bvp(x, fx, coeffs, bd_cond)(probe)[0]
+
+    assert_allclose(first, second, atol=0.0, rtol=0.0)
+    assert_allclose(first, probe**2.0 / 2.0 - probe, atol=1e-6)
+
+
 @pytest.mark.parametrize(
     "fx, coeffs, ivp, solutions",
     [


### PR DESCRIPTION
## What

`solve_ode_bvp` seeded its default `initial_guess_y` with `np.random.rand(order, x.size)`, so any call that doesn't pass an explicit guess depends on global `np.random` state.

`solve_poisson_bvp` / `solve_poisson_ivp` never pass a guess, so **every Poisson solve is non-reproducible run to run** — it can converge or hit `max_nodes` depending on RNG state, and the `atol=1e-2` Poisson tests are flaky by construction (no seeding in the test suite).

## Change

- Replace the random default with an all-zeros guess. The ODE solved here is **linear**, so the initial guess cannot change the converged solution — only mesh adaptation — so this is safe.
- Update the docstring.
- Add `test_solve_ode_bvp_default_initial_guess_is_deterministic`: the same linear BVP solved under two different global RNG states now gives bit-identical results.

## Testing

`pytest src/grid/tests/test_ode.py src/grid/tests/test_poisson.py` passes locally. Callers can still pass `initial_guess_y` explicitly to override.