### PR TITLE
Enable two-center case in test_poisson_bvp_gives_the_correct_laplacian

### DIFF
--- a/src/grid/tests/test_poisson.py
+++ b/src/grid/tests/test_poisson.py
@@ -236,11 +236,7 @@ def test_poisson_bvp_on_unit_charge_distribution(oned, tf, remove_large_pts, cen
         [zero_func, np.array([[0.0, 0.0, 0.0]])],
         [gauss, np.array([[0.0, 0.0, 0.0]])],
         [gauss, np.array([[1.0, 0.0, 0.0]])],
-        # TODO: Couldn't get the following test to pass.
-        # [
-        #     lambda pts, centers: gauss(pts, centers),
-        #     np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
-        # ]
+        [gauss, np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])],
     ],
 )
 def test_poisson_bvp_gives_the_correct_laplacian(func, centers):


### PR DESCRIPTION
This case was commented out with `# TODO: Couldn't get the following test to pass.` I ran it against current master (two Gaussians at (0,0,0) and (1,1,1), default params) and it passes: max abs error ~6e-3 on grid points and ~3e-14 on random points, both under the existing atol=1e-2. Looks like it was fixed as a side effect of other work since this was written, just never re-checked. Uncommenting it.